### PR TITLE
userData state is now initialized as an empty object

### DIFF
--- a/src/useOauth.js
+++ b/src/useOauth.js
@@ -25,9 +25,10 @@ const useOauth = (config = {}, logoutUrl = '') => {
   let mounted = true;
 
   const initialAuthData = {isLogged: false, oauthTokens: null};
+  const initialUserData = {};
 
   const [authData, setAuthData] = useState(initialAuthData);
-  const [userData, setUserData] = useState(null);
+  const [userData, setUserData] = useState(initialUserData);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
 

--- a/test/useOauth.test.js
+++ b/test/useOauth.test.js
@@ -95,6 +95,6 @@ describe('useOauth hook', () => {
     );
     const {result, waitForNextUpdate} = renderHook(() => useOauth());
     await waitForNextUpdate();
-    expect(result.current.userData).toBeNull();
+    expect(result.current.userData).toEqual({});
   });
 });


### PR DESCRIPTION
Link del ticket: [https://fizzmod.atlassian.net/browse/APPSRN-51](https://fizzmod.atlassian.net/browse/APPSRN-51)

- Se cambio el valor inicial del state `userData` a un objeto vacio para que no rompan las apps al querer destructurar `userData`.
- Se ajustaron los tests.

**Para probar el cambio en la app con el package local:**

Hay que tener instalado `watchman` antes de realizar los siguientes pasos:
- Instalar `wml` globalmente con `npm i -g wml`. Este paquete te permite copiar archivos de un lugar a otro y escucha los cambios de los archivos para actualizarlos en el destino.
- Linkear el paquete local con la app con el comando `wml add <src> <dest>` donde `src` deberia ser la carpeta del paquete y `dest` deberia ser la carpeta del paquete dentro de `node_modules` del proyecto. Ej: `wml add oauth-native/src janis-picking-rn/node_modules/@janiscommerce/oauth-native/src`
- En una terminal iniciar `wml` con `wml start` para que copie el paquete a la app.
- Iniciar metro con `npm start` e iniciar la app con `npm run android:beta`.
- Validar que la app funcione correctamente y no hayan errores con el paquete.