### PR TITLE
Test/auth token error

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
     "prettier": "^2.2.1",
     "react": "^16.13.1",
     "react-native": "^0.63.4",
-    "react-test-renderer": "16.13.1",
     "react-native-app-auth": "^6.2.0",
-    "react-native-inappbrowser-reborn": "^3.5.1"
+    "react-native-inappbrowser-reborn": "^3.5.1",
+    "react-test-renderer": "16.13.1"
   },
   "peerDependencies": {
     "react": ">= 16.13.1",

--- a/src/useOauth.js
+++ b/src/useOauth.js
@@ -31,7 +31,7 @@ const useOauth = (config = {}, logoutUrl = '') => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
 
-  const {oauthTokens = {}} = authData;
+  const {oauthTokens} = authData;
   const {idToken = ''} = oauthTokens;
 
   /**
@@ -85,24 +85,21 @@ const useOauth = (config = {}, logoutUrl = '') => {
 
   const handleDecodeToken = () => {
     try {
-      if (!authData.oauthTokens) return;
-
-      const {idToken = ''} = authData.oauthTokens;
-  
       if (idToken) {
         const decoded = jwtDecode(idToken);
+        // istanbul ignore next
         if (decoded) {
           setUserData(decoded);
         }
       }
     } catch (e) {
-      console.warn(e)
+      console.warn(e);
       setError('Error in decoding tokens');
       setLoading(false);
     }
-  }
+  };
 
-   /**
+  /**
    * @name handleValidateLogin
    * @description method to validate login
    * @public
@@ -121,14 +118,12 @@ const useOauth = (config = {}, logoutUrl = '') => {
 
       setAuthData(res);
       setLoading(false);
-   
     } catch (e) {
-      console.warn(e)
+      console.warn(e);
       setError('Error in validating login');
       setLoading(false);
     }
-  }
-    
+  };
 
   useEffect(() => {
     handleValidateLogin();

--- a/src/utils/oauth.js
+++ b/src/utils/oauth.js
@@ -136,7 +136,7 @@ export const userAuthorize = async (config = {}) => {
  */
 export const getLoginObj = (tokens) => ({
   isLogged: !!tokens,
-  oauthTokens: tokens || null,
+  oauthTokens: tokens || {},
 });
 
 /**

--- a/test/utils/oauth.test.js
+++ b/test/utils/oauth.test.js
@@ -200,7 +200,7 @@ describe('OAuth Utils', () => {
 
       expect(loginData).toEqual({
         isLogged: false,
-        oauthTokens: null,
+        oauthTokens: {},
       });
     });
   });
@@ -210,7 +210,7 @@ describe('OAuth Utils', () => {
       const res = await getAuthData();
       expect(res).toEqual({
         isLogged: false,
-        oauthTokens: null,
+        oauthTokens: {},
       });
     });
 


### PR DESCRIPTION
LINK DE TICKET: *
https://janiscommerce.atlassian.net/browse/JDAPP-981

DESCRIPCIÓN DEL REQUERIMIENTO: *
Contexto
Actualmente al querer ingresar por primera vez a la app aparece un error:
![image](https://user-images.githubusercontent.com/49655553/225395111-40d27215-9712-42d1-92a3-34d07df39700.png)


Resultando que en un dispositivo físico, se cierre.

Necesidad
Poder loguearse sin que rompa la app

DESCRIPCIÓN DE LA SOLUCIÓN: *
- Se valida que exista la key idToken antes de usarla
- Se encierra la función de logueo escuchando cambios de idToken
- Se agregan varios try catch para validar errores

CÓMO SE PUEDE PROBAR? *
Siguiendo la documentación: https://janiscommerce.atlassian.net/wiki/spaces/JAPP/pages/2341765125/C+mo+trabajo+con+el+package+UI
pero a la hora de usar el comando yalc add, se deber de usar de la siguiente manera: yalc add @janiscommerce/oauth-native

En caso de que ya estemos logueados en la app, intentar desloguearse y volver a loguear, eso ya debe de funcionar correctamente

SCREENSHOTS:

LINK PR QA:

DATOS EXTRA A TENER EN CUENTA: