### PR TITLE
added try catch to decode token function

### DIFF
--- a/src/useOauth.js
+++ b/src/useOauth.js
@@ -98,14 +98,21 @@ const useOauth = (config = {}, logoutUrl = '') => {
   }, [authData.isLogged]);
 
   useEffect(() => {
-    if (!authData.oauthTokens) return;
+    try {
+      if (!authData.oauthTokens) return;
 
-    const {idToken = ''} = authData.oauthTokens;
+      const {idToken = ''} = authData.oauthTokens;
 
-    const decoded = jwtDecode(idToken);
+      const decoded = jwtDecode(idToken);
 
-    if (decoded) {
-      setUserData(decoded);
+      // istanbul ignore next
+      if (decoded) {
+        setUserData(decoded);
+      }
+    } catch (reason) {
+      console.warn(reason);
+      setError('Error in decoding token');
+      setLoading(false);
     }
   }, [authData.oauthTokens]);
 

--- a/test/useOauth.test.js
+++ b/test/useOauth.test.js
@@ -1,13 +1,16 @@
 import React from 'react';
 import {renderHook, act} from '@testing-library/react-hooks';
+import * as jwtDecode from 'jwt-decode';
 import * as OAuthUtils from '../src/utils/oauth';
 import * as browserUtils from '../src/utils/browser';
 import * as promisesUtils from '../src/utils/promises';
 import useOauth from '../src/useOauth';
 
-jest.mock('jwt-decode', () =>
-  jest.fn(() => null).mockImplementationOnce(() => ({name: 'example'})),
-);
+// jest.mock('jwt-decode', () =>
+//   jest.fn(() => null).mockImplementationOnce(() => ({name: 'example'})),
+// );
+
+const spyOnJwtDecode = jest.spyOn(jwtDecode, 'default');
 
 describe('useOauth hook', () => {
   afterEach(() => {
@@ -15,29 +18,34 @@ describe('useOauth hook', () => {
   });
 
   test('should initiate with true loading', async () => {
+    spyOnJwtDecode.mockReturnValueOnce(() => ({name: 'example'}));
     const {result} = renderHook(() => useOauth());
     expect(result.current.loading).toBe(true);
   });
 
   test('should update loading to false', async () => {
+    spyOnJwtDecode.mockReturnValueOnce(() => ({name: 'example'}));
     const {result, waitForNextUpdate} = renderHook(() => useOauth());
     await waitForNextUpdate();
     expect(result.current.loading).toBe(false);
   });
 
   test('must call 2 useEffect functions', () => {
+    spyOnJwtDecode.mockReturnValueOnce(() => ({name: 'example'}));
     jest.spyOn(React, 'useEffect');
     renderHook(() => useOauth());
     expect(React.useEffect).toHaveBeenCalledTimes(2);
   });
 
   test('must call getAuthData 1 time', () => {
+    spyOnJwtDecode.mockReturnValueOnce(() => ({name: 'example'}));
     jest.spyOn(OAuthUtils, 'getAuthData');
     renderHook(() => useOauth());
     expect(OAuthUtils.getAuthData).toHaveBeenCalledTimes(1);
   });
 
   test('must call userAuthorize', async () => {
+    spyOnJwtDecode.mockReturnValueOnce(() => ({name: 'example'}));
     jest.spyOn(OAuthUtils, 'userAuthorize');
     const {waitForNextUpdate} = renderHook(() => useOauth());
     await waitForNextUpdate();
@@ -45,6 +53,7 @@ describe('useOauth hook', () => {
   });
 
   test('must call logout method', async () => {
+    spyOnJwtDecode.mockReturnValueOnce(() => ({name: 'example'}));
     jest.spyOn(browserUtils, 'logout');
     const {waitForNextUpdate, result} = renderHook(() => useOauth());
 
@@ -57,6 +66,7 @@ describe('useOauth hook', () => {
   });
 
   test('must setError if something failed in handleLogout', async () => {
+    spyOnJwtDecode.mockReturnValueOnce(() => ({name: 'example'}));
     jest.spyOn(browserUtils, 'logout').mockImplementation(() => {
       throw new Error('Something has failed');
     });
@@ -75,6 +85,7 @@ describe('useOauth hook', () => {
   });
 
   test('should update authData', async () => {
+    spyOnJwtDecode.mockReturnValueOnce(() => ({name: 'example'}));
     jest.spyOn(OAuthUtils, 'getAuthData').mockImplementation(() =>
       Promise.resolve({
         isLogged: true,
@@ -87,6 +98,7 @@ describe('useOauth hook', () => {
   });
 
   test('should update authData', async () => {
+    spyOnJwtDecode.mockReturnValueOnce(() => ({name: 'example'}));
     jest.spyOn(OAuthUtils, 'getAuthData').mockImplementation(() =>
       Promise.resolve({
         isLogged: true,
@@ -96,5 +108,33 @@ describe('useOauth hook', () => {
     const {result, waitForNextUpdate} = renderHook(() => useOauth());
     await waitForNextUpdate();
     expect(result.current.userData).toEqual({});
+  });
+  it('should call decode with fake value in true', async () => {
+    spyOnJwtDecode.mockReturnValueOnce(() => ({name: 'example'}));
+    jest.spyOn(OAuthUtils, 'getAuthData').mockImplementation(() =>
+      Promise.resolve({
+        isLogged: true,
+        oauthTokens: {idToken: 'FAKE.eyJmYWtlIjogdHJ1ZX0='},
+      }),
+    );
+    const {result, waitForNextUpdate} = renderHook(() => useOauth());
+
+    await waitForNextUpdate();
+    console.log('result.current', result.current);
+    expect(result.current.isLogged).toStrictEqual(true);
+  });
+  it('should call decode with fake value in true', async () => {
+    spyOnJwtDecode.mockReturnValueOnce(() => false);
+    jest.spyOn(OAuthUtils, 'getAuthData').mockImplementation(() =>
+      Promise.resolve({
+        isLogged: true,
+        oauthTokens: {idToken: 'eyJmYWtlIjogdHJ1ZX0='},
+      }),
+    );
+    const {result, waitForNextUpdate} = renderHook(() => useOauth());
+
+    await waitForNextUpdate();
+
+    expect(result.current.isLogged).toStrictEqual(true);
   });
 });


### PR DESCRIPTION
LINK DE TICKET: *
https://janiscommerce.atlassian.net/browse/JDAPP-981

DESCRIPCIÓN DEL REQUERIMIENTO: *
Contexto
Actualmente al querer ingresar por primera vez a la app aparece un error:
![image](https://user-images.githubusercontent.com/49655553/225674659-17e48b21-d3a4-4fcd-b119-278e78b205a2.png)


Resultando que en un dispositivo físico, se cierre.

Necesidad
Poder loguearse sin que rompa la app

DESCRIPCIÓN DE LA SOLUCIÓN: *
Se agrega un try catch para evitar que rompa en caso de que haya un error
CÓMO SE PUEDE PROBAR? *
Siguiendo la documentación: https://janiscommerce.atlassian.net/wiki/spaces/JAPP/pages/2341765125/C+mo+trabajo+con+el+package+UI
pero a la hora de usar el comando yalc add, se deber de usar de la siguiente manera: yalc add @janiscommerce/oauth-native

En caso de que ya estemos logueados en la app, intentar desloguearse y volver a loguear, eso ya debe de funcionar correctamente

SCREENSHOTS:

LINK PR QA:

DATOS EXTRA A TENER EN CUENTA: