### PR TITLE
cambiar funcion para obtener token en getUserData y exportar getAuthData por afuera del context

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "start": "react-native start",
-    "test": "jest --colors --c jest.config.json",
+    "test": "jest --colors --c jest.config.json --passWithNoTests",
     "test:coverage": "jest --collectCoverage",
     "lint": "eslint ."
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "start": "react-native start",
-    "test": "jest --colors --c jest.config.json --passWithNoTests",
+    "test": "jest --colors --c jest.config.json",
     "test:coverage": "jest --collectCoverage",
     "lint": "eslint ."
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+export {getAuthData} from './utils/oauth';
 export * from './useOauthData';
 export * from './utils/getUserInfo';
 export {default} from './Provider';

--- a/src/utils/getUserInfo.js
+++ b/src/utils/getUserInfo.js
@@ -1,5 +1,5 @@
 import jwtDecode from 'jwt-decode';
-import {getTokensCache} from './oauth';
+import {getAuthData} from './oauth';
 
 /**
  * @name getUserInfo
@@ -10,7 +10,7 @@ import {getTokensCache} from './oauth';
  */
 export const getUserInfo = async () => {
   try {
-    const {oauthTokens} = await getTokensCache();
+    const {oauthTokens} = await getAuthData();
 
     if (!Object.keys(oauthTokens).length)
       throw new Error('cant get oauth tokens');


### PR DESCRIPTION
### LINK DE TICKET: 

https://janiscommerce.atlassian.net/browse/APPSRN-243

### DESCRIPCIÓN DEL REQUERIMIENTO: 

**Contexto**
Hace unos dias se agrego una nueva funcion getUserInfo en el pkg [oauth](https://github.com/janis-commerce/oauth-native/pull/5) para obtener la informacion del usuario en base al los tokens. El problema es que revisando codigo nos dimos cuenta que estamos obteniendo los token sin tener en cuenta que pueden estar expirados. 

**Necesidad**
Cambiar la funcion que usamos para obtener los token necesarios. En caso de estar expirados, se deben obtener unos nuevos tokens


### DESCRIPCIÓN DE LA SOLUCIÓN: 

- Se reemplaza **getTokensCache** por **getAuthData** en la función **getUserInfo**.  Cumple la misma función pero la diferencia es que cuando el token está vencido, éste se actualiza.
- se exporta **getAuthData** por el index (fuera del contexto), para poder ser utilizado en próximos desarrollos


### CÓMO SE PUEDE PROBAR? 

1. Entramos a la rama **APPSRN-244-cambiar-funcion-para-obtener-token-en-get-user-info** en **@janis-commerce/oauth-native**
2. En consola tiramos **yalc push && yalc publish** 
3. En el repo de nuestra app tiramos **yalc add @janiscommerce/oauth-native** y npm i
4. En la página home agregamos lo siguiente:

```
import {getUserInfo} from '@janiscommerce/oauth-native';
  
  ...
  
  const initUserInfo = async () => {
    const [userInfo, userInfoError] = await promiseWrapper(getUserInfo());

    if (userInfoError) {
      return console.log({userInfoError})
    }
    return console.log({userInfo})
  }

  useEffect(() => {
    initUserInfo();
  }, [])
```


