### PR TITLE
Agregar funcion getAccessToken

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -5,7 +5,7 @@
   "moduleDirectories": ["node_modules", "src"],
   "clearMocks": true,
   "moduleFileExtensions": ["js", "jsx", "json"],
-  "testMatch": ["**/__tests__/**/*.js?(x)", "**/?(*.)+(spec|test).js?(x)"],
+  "testMatch": ["**/__tests__/**/*.js?(x)", "**/?(*.)+(spec|test).js?(x)", "**/__tests__/**/*.test.js"],
   "setupFilesAfterEnv": ["./jest.setup.js"],
   "coverageReporters": ["html", "text", "lcov"],
   "coverageDirectory": "coverage",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2591,6 +2591,16 @@
       "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
       "dev": true
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bplist-creator": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.0.8.tgz",
@@ -4665,6 +4675,13 @@
       "requires": {
         "flat-cache": "^3.0.4"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "dev": true,
+      "optional": true
     },
     "fill-range": {
       "version": "7.0.1",
@@ -7315,7 +7332,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "jest-haste-map": {
           "version": "24.9.0",
@@ -7913,7 +7934,11 @@
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "dev": true,
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "jest-haste-map": {
           "version": "24.9.0",
@@ -8386,6 +8411,13 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export {getAuthData} from './utils/oauth';
 export * from './useOauthData';
 export * from './utils/getUserInfo';
+export * from './utils/getAccessToken';
 export {default} from './Provider';

--- a/src/utils/getAccessToken.js
+++ b/src/utils/getAccessToken.js
@@ -1,0 +1,25 @@
+import {getAuthData} from './oauth';
+
+/**
+ * @name getAccessToken
+ * @description Function to return accessToken of oauth
+ * @returns {string} accessToken
+ */
+export const getAccessToken = async () => {
+  try {
+    const data = await getAuthData();
+    const {oauthTokens} = data || {};
+
+    if (!oauthTokens || !Object.keys(oauthTokens).length)
+      throw new Error('cant get oauth tokens');
+
+    const {accessToken = ''} = oauthTokens;
+
+    if (!accessToken || typeof accessToken !== 'string')
+      throw new Error('cant get accessToken');
+
+    return accessToken;
+  } catch (error) {
+    return Promise.reject(error);
+  }
+};

--- a/src/utils/getAccessToken.js
+++ b/src/utils/getAccessToken.js
@@ -3,7 +3,7 @@ import {getAuthData} from './oauth';
 /**
  * @name getAccessToken
  * @description Function to return accessToken of oauth
- * @returns {string} accessToken
+ * @returns {Promise<string>} accessToken
  */
 export const getAccessToken = async () => {
   try {

--- a/test/utils/getAccessToken.test.js
+++ b/test/utils/getAccessToken.test.js
@@ -1,0 +1,42 @@
+import {getAccessToken} from '../../src/utils/getAccessToken';
+import * as oauth from '../../src/utils/oauth';
+
+describe('getAccessToken', () => {
+  describe('reject with error', () => {
+    it.each([null, undefined, 'test', {}, false, true, {oauthTokens: {}}])(
+      'error - invalid oauthTokens object',
+      async (invalidAuthData) => {
+        oauth.getAuthData = jest.fn().mockReturnValueOnce(invalidAuthData);
+
+        await expect(getAccessToken()).rejects.toThrowError(
+          'cant get oauth tokens',
+        );
+      },
+    );
+
+    it.each([null, undefined, {}, false, true, {oauthTokens: {}}])(
+      'error - invalid accessToken',
+      async (invalidAccessToken) => {
+        oauth.getAuthData = jest.fn().mockReturnValueOnce({
+          oauthTokens: {accessToken: invalidAccessToken},
+        });
+
+        await expect(getAccessToken()).rejects.toThrowError(
+          'cant get accessToken',
+        );
+      },
+    );
+  });
+
+  it('returns the accessToken', async () => {
+    oauth.getAuthData = jest.fn().mockReturnValueOnce({
+      oauthTokens: {
+        accessToken: 'test123',
+      },
+    });
+
+    const accessToken = await getAccessToken();
+
+    expect(accessToken).toBe('test123');
+  });
+});


### PR DESCRIPTION
LINK TICKET: 
https://janiscommerce.atlassian.net/browse/APPSRN-260

CONTEXTO
Actualmente para obtener el accessToken en las apps, se debe utilizar el hook useOauthData(). El principal problema de esto, es que nos obliga a gettear el token dentro de react. 

El escenario mas comun es al momento de realizar las requests

Dentro de una funcion, se deben poder obtener el accessToken y el client

El client lo podemos obtener desde getUserInfo(), pero en este objeto no viene el accessToken


NECESIDAD

El package oauth-native, debe exportar una funcion que retorne el accessToken.


SOLUCION: 
Se agrego la funcion getAccessToken(), la cual primero obtiene los tokens de getAuthData().
Dentro de getAuthData(), ya se encuentra la validacion necesaria para que los tokens esten siempre actualizados.
Retorna el accessToken en formato de string.

COMO PROBARLO:
Linkear el package oauth-native con alguna app.
yalc add @janiscommerce/oauth-native

Documentacion para linkear packages con yalc https://janiscommerce.atlassian.net/wiki/spaces/JAPP/pages/2341765125/C+mo+trabajo+con+el+package+UI


Dentro de la app, en la screen Home agregar el siguiente codigo
```
import {getAccessToken} from '@janiscommerce/oauth-native'

useEffect(() => {
		const getToken = async () => {
			const accessToken = await getAccessToken();
			console.log('accessToken :>> ', accessToken);
		};

		getToken();
	});
```