### PR TITLE
fixed type error in getUserInfo

### DIFF
--- a/src/utils/getUserInfo.js
+++ b/src/utils/getUserInfo.js
@@ -12,6 +12,8 @@ export const getUserInfo = async () => {
   try {
     const {oauthTokens} = await getAuthData();
 
+    if (!oauthTokens || oauthTokens.constructor !== Object) return null;
+
     if (!Object.keys(oauthTokens).length)
       throw new Error('cant get oauth tokens');
 

--- a/test/useOauth.test.js
+++ b/test/useOauth.test.js
@@ -130,7 +130,7 @@ describe('useOauth hook', () => {
     const {result, waitForNextUpdate} = renderHook(() => useOauth());
 
     await waitForNextUpdate();
-    console.log('result.current', result.current);
+
     expect(result.current.isLogged).toStrictEqual(true);
   });
   it('should call decode with fake value in true', async () => {

--- a/test/utils/getUserInfo.test.js
+++ b/test/utils/getUserInfo.test.js
@@ -46,6 +46,16 @@ describe('getUserInfo', () => {
     });
   });
 
+  describe('return null when', () => {
+    it('obtains null oauthData or this is not an object', async () => {
+      jest.spyOn(AsyncStorage, 'getItem').mockReturnValueOnce(null);
+
+      const response = await getUserInfo();
+
+      expect(response).toBeNull();
+    });
+  });
+
   describe('returns with', () => {
     it('a correct response', async () => {
       const dataMock = {idToken: 'example'};


### PR DESCRIPTION
LINK DE TAREA:
https://janiscommerce.atlassian.net/browse/APPSRN-306

LINK DE SUBTAREA:
https://janiscommerce.atlassian.net/browse/APPSRN-307

CONTEXTO:

Actualmente todas las apps, cuando se inician, arrojan este error en el entorno de desarrollo:
![Captura desde 2024-05-24 16-05-40](https://github.com/janis-commerce/oauth-native/assets/75044106/c3510461-bbce-422d-b71c-c5235967b7a8)

Revisando, encontramos que este error se produce por el package de app-request, pero no es propio de app-request, sino que surge en oauth-tokens, en el método getUserInfo (que lo usamos en app-request).

Este error se debe a que, en el primer renderizado de la app, el valor obtenido es nulo y rompe una validación que espera recibir un objeto, por lo que en desarrollo muestra el error "cannot convert null value to object".


SOLUCIÓN:


Para corregir esto, lo que hicimos fue agregar una validación previa en la que, si el valor obtenido es nulo o no es un objeto, este método retornará un valor nulo, evitando que se llegue a la validación que espera un objeto.

Hay que recordar que el método getUserInfo es utilizado en varios packages para getear la data y poder utilizarlo, por lo que la validación de lo obtenido y el manejo de errores deberá ajustarse en base a esta modificación si es necesario.

CÓMO PROBARLO?

Corriendo los test del package.