### PR TITLE
added expired token validation

### DIFF
--- a/src/utils/oauth.js
+++ b/src/utils/oauth.js
@@ -157,6 +157,10 @@ export const getAuthData = async (config = {}) => {
       return getLoginObj(newTokens);
     }
 
+    if (isExpired(expiration)) {
+      return getLoginObj();
+    }
+
     return getLoginObj(oauthTokens);
   } catch (error) {
     return getLoginObj();

--- a/test/utils/oauth.test.js
+++ b/test/utils/oauth.test.js
@@ -305,6 +305,50 @@ describe('OAuth Utils', () => {
         console.error('e', e);
       }
     });
+
+    it('must return object with isLogged false and null tokens data', async () => {
+      const config = {
+        issuer: 'https://app.example.com',
+        clientId: 'c1e2e8d5-ccea-47aa-9075-f9741fe11452',
+        redirectUrl: 'example/callback',
+        scopes: ['openid', 'profile', 'email', 'offline_access'],
+        serviceConfiguration: {
+          authorizationEndpoint: 'https://app.example.com/oauth/authorize',
+          tokenEndpoint: 'https://app.example.com/2.0/token',
+        },
+      };
+
+      const now = Date.now();
+      const tomorrow = now + 86400000;
+      const date = new Date(tomorrow).toDateString();
+
+      await storeTokensCache({
+        accessTokenExpirationDate: date,
+        tokenType: 'Bearer',
+        expiresIn: 172799,
+        scope: 'openid profile email oms:order:read',
+        accessToken: 'access-token-1',
+        idToken: 'id-token-1',
+      });
+
+      const res = await getAuthData(config);
+
+      try {
+        expect(res).toEqual({
+          isLogged: true,
+          oauthTokens: {
+            accessTokenExpirationDate: date,
+            tokenType: 'Bearer',
+            expiresIn: 172799,
+            scope: 'openid profile email oms:order:read',
+            accessToken: 'access-token-1',
+            idToken: 'id-token-1',
+          },
+        });
+      } catch (e) {
+        console.error('e', e);
+      }
+    });
   });
 
   describe('clearAuthorizeTokens', () => {

--- a/test/utils/oauth.test.js
+++ b/test/utils/oauth.test.js
@@ -306,7 +306,7 @@ describe('OAuth Utils', () => {
       }
     });
 
-    it('must return object with isLogged false and null tokens data', async () => {
+    it('must return object with isLogged true and tokens data when current tokens are valid', async () => {
       const config = {
         issuer: 'https://app.example.com',
         clientId: 'c1e2e8d5-ccea-47aa-9075-f9741fe11452',


### PR DESCRIPTION
**CONTEXTO:**

En base a un reclamo por parte de "La Torre" nos dimos cuenta que la app no estaba realizando el deslogueo del usuario cuando los tokens de acceso se encontraban expirados. Esto generaba que, al realizar request a todas las apis, respondieran con un error 401, lo que evitaba al usuario poder operar con cualquier flujo de la app.

Revisando, nos dimos cuenta que el package de oauth realiza la validación del token para saber si está expirado sólo cuando se cuenta con un `refresh-token`; dato con el que la app ya no está contando por haber eliminado el permiso de `offline_access` del scope de permisos.

**SOLUCIÓN:**

Se agregó una segunda  validación dentro de la utils `getAuthData` para que, en caso de que el usuario no cuente con el refresh-token, pero su token actual se encuentre expirado, se seteen valores para forzar el logout de la app y que el usuario deba volver a logearse para operar. De esta manera se resolvería el problema reportado.

**CÓMO PROBARLO?:**

La manera rápida sería corriendo los test para validar que, cuando el token se encuentra todavía activo, los valores de logged y oauthTokens, sean true y los datos asociados al token. Esto se puede ver en el test de la linea 309 del test `oauth.test.js`

