### PR TITLE
Added WithTokensExpirationAccess HOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,14 +103,14 @@ The method **getUserInfo** compared to **useOauthData.userData** is not context 
 | ----------- | ------ | ---------------------------------------------------- |
 | getUserInfo | object | user data information without depending on a context |
 
-### WithTokensExpirationAccess HOC
+### withTokensExpirationAccess HOC
 
 HOC that provides automatic token expiration handling to wrapped components. It monitors the access token and refreshes it if it’s about to expire, ensuring the user session stays active without manual intervention as well as providing the option to alert the user some time before
 the token expires.
 
 ```js
 // SomeScreen.js
-import {WithTokensExpirationAccess} from '@janiscommerce/oauth-native';
+import {withTokensExpirationAccess} from '@janiscommerce/oauth-native';
 
 const SomeScreen = () => {
   return (
@@ -120,7 +120,7 @@ const SomeScreen = () => {
   );
 };
 
-export default WithTokensExpirationAccess(SomeScreen, {
+export default withTokensExpirationAccess(SomeScreen, {
   onTokenNearExpiration: () =>
     Toast.show({text2: 'Token near expiration!', type: 'warning'}),
   onTokenExpired: () => console.log('Log out!'),

--- a/README.md
+++ b/README.md
@@ -99,6 +99,38 @@ const ChildrenComponent = () => {
 
 The method **getUserInfo** compared to **useOauthData.userData** is not context dependent.
 
-| state           | Type           | description                                                          |
-| --------------- | -------------- | -------------------------------------------------------------------- |
-| getUserInfo     | object         | user data information without depending on a context                 |
+| state       | Type   | description                                          |
+| ----------- | ------ | ---------------------------------------------------- |
+| getUserInfo | object | user data information without depending on a context |
+
+### WithTokensExpirationAccess HOC
+
+HOC that provides automatic token expiration handling to wrapped components. It monitors the access token and refreshes it if it’s about to expire, ensuring the user session stays active without manual intervention as well as providing the option to alert the user some time before
+the token expires.
+
+```js
+// SomeScreen.js
+import {WithTokensExpirationAccess} from '@janiscommerce/oauth-native';
+
+const SomeScreen = () => {
+  return (
+    <View>
+      <Text>Screen</Text>
+    </View>
+  );
+};
+
+export default WithTokensExpirationAccess(SomeScreen, {
+  onTokenNearExpiration: () =>
+    Toast.show({text2: 'Token near expiration!', type: 'warning'}),
+  onTokenExpired: () => console.log('Log out!'),
+});
+```
+
+**WithTokensExpirationAccess Configuration Options:**
+
+| config option              | Type     | Description                                                                                          |
+| -------------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
+| minimumTokenExpirationTime | number   | Time in minutes before token expiration to trigger near-expiration callback. Default is 120 minutes. |
+| onTokenNearExpiration      | function | Callback function triggered when the token is near expiration.                                       |
+| onTokenExpired             | function | Callback function triggered when the token is expired. Also logs the user out.                       |

--- a/src/WithTokensExpirationAccess.js
+++ b/src/WithTokensExpirationAccess.js
@@ -1,0 +1,60 @@
+import React, {useEffect} from 'react';
+import {getTokensCache} from './utils/oauth';
+import {useOauthData} from './useOauthData';
+
+/**
+ * Higher Order Component that checks if the access token is about to expire
+ * and if so, it logs out the user and calls the callback function.
+ *
+ * The check is done when the component is mounted and the callback is executed
+ * only if the token has reached the expiration threshold.
+ *
+ * By default the expiration threshold is 120 minutes.
+ *
+ * @param {React.Component} Component - The component to wrap.
+ * @param {object} config - Object with the configuration options.
+ * @param {number} config.minimumTokenExpirationTime - The minimum time in minutes
+ * before the token expires to execute the callback.
+ * @param {function} config.callback - The callback function to execute when the token
+ * has reached the expiration threshold.
+ *
+ * @return {React.Component} The wrapped component.
+ */
+export const WithTokensExpirationAccess = (Component, config = {}) => (
+  props,
+) => {
+  const {handleLogout: logout} = useOauthData();
+
+  const {minimumTokenExpirationTime = 120, callback = () => {}} = config;
+
+  const hasReachedExpirationThreshold = (
+    expirationTime,
+    timeBeforeExpiration,
+  ) => {
+    const currentTime = Date.now();
+    const timeDifference = expirationTime - currentTime;
+    const expirationThreshold = timeBeforeExpiration * 60 * 1000;
+
+    return timeDifference <= expirationThreshold;
+  };
+
+  const verifyExpiration = async () => {
+    const {expiration} = await getTokensCache();
+
+    const needToExecuteCallback = hasReachedExpirationThreshold(
+      expiration,
+      minimumTokenExpirationTime,
+    );
+
+    if (needToExecuteCallback) {
+      callback();
+      logout();
+    }
+  };
+
+  useEffect(() => {
+    verifyExpiration();
+  }, []);
+
+  return <Component {...props} />;
+};

--- a/src/WithTokensExpirationAccess.js
+++ b/src/WithTokensExpirationAccess.js
@@ -48,10 +48,8 @@ export const WithTokensExpirationAccess = (Component, config = {}) => (
         callback();
         logout();
       }
-
-      return null;
-    } catch (reason) {
-      return Promise.reject(reason?.response?.data || reason);
+    } catch (error) {
+      console.error('Error verifying token expiration:', error);
     }
   };
 

--- a/src/WithTokensExpirationAccess.js
+++ b/src/WithTokensExpirationAccess.js
@@ -47,17 +47,24 @@ export const WithTokensExpirationAccess = (Component, config = {}) => (
   const checkTokenExpiration = async () => {
     try {
       const {expiration} = await getTokensCache();
+      const isExpired = isTokenExpired(expiration);
+      const isNearExpiration = isTokenNearExpiration(
+        expiration,
+        minimumTokenExpirationTime,
+      );
 
-      if (isTokenExpired(expiration)) {
+      if (isExpired) {
         onTokenExpired();
-        logout();
-      } else if (
-        isTokenNearExpiration(expiration, minimumTokenExpirationTime)
-      ) {
-        onTokenNearExpiration();
+        return logout();
       }
+
+      if (isNearExpiration) {
+        return onTokenNearExpiration();
+      }
+
+      return null;
     } catch (error) {
-      console.error('Error verifying token expiration:', error);
+      return console.error('Error verifying token expiration:', error);
     }
   };
 

--- a/src/WithTokensExpirationAccess.js
+++ b/src/WithTokensExpirationAccess.js
@@ -2,6 +2,17 @@ import React, {useEffect} from 'react';
 import {getTokensCache} from './utils/oauth';
 import {useOauthData} from './useOauthData';
 
+const isTokenExpired = (expirationTime) => {
+  const currentTime = Date.now();
+  return expirationTime <= currentTime;
+};
+
+const isTokenNearExpiration = (expirationTime, thresholdInMinutes) => {
+  const currentTime = Date.now();
+  const thresholdInMs = thresholdInMinutes * 60 * 1000;
+  return expirationTime - currentTime <= thresholdInMs;
+};
+
 /**
  * Higher Order Component that checks if the access token is about to expire
  * and if so, it logs out the user and calls the callback function.
@@ -15,8 +26,10 @@ import {useOauthData} from './useOauthData';
  * @param {object} config - Object with the configuration options.
  * @param {number} config.minimumTokenExpirationTime - The minimum time in minutes
  * before the token expires to execute the callback.
- * @param {function} config.callback - The callback function to execute when the token
+ * @param {function} config.onTokenNearExpiration - The callback function to execute when the token
  * has reached the expiration threshold.
+ * @param {function} config.onTokenExpired - The callback function to execute when the token
+ * has expired.
  *
  * @return {React.Component} The wrapped component.
  */
@@ -25,28 +38,23 @@ export const WithTokensExpirationAccess = (Component, config = {}) => (
 ) => {
   const {handleLogout: logout} = useOauthData();
 
-  const {minimumTokenExpirationTime = 120, callback = () => {}} = config;
-
-  const isTokenNearExpiration = (expirationTime, timeBeforeExpiration) => {
-    const currentTime = Date.now();
-    const remainingTimeUntilExpiration = expirationTime - currentTime;
-    const expirationThreshold = timeBeforeExpiration * 60 * 1000;
-
-    return remainingTimeUntilExpiration <= expirationThreshold;
-  };
+  const {
+    minimumTokenExpirationTime = 120,
+    onTokenNearExpiration = () => {},
+    onTokenExpired = () => {},
+  } = config;
 
   const checkTokenExpiration = async () => {
     try {
       const {expiration} = await getTokensCache();
 
-      const needToExecuteCallback = isTokenNearExpiration(
-        expiration,
-        minimumTokenExpirationTime,
-      );
-
-      if (needToExecuteCallback) {
-        callback();
+      if (isTokenExpired(expiration)) {
+        onTokenExpired();
         logout();
+      } else if (
+        isTokenNearExpiration(expiration, minimumTokenExpirationTime)
+      ) {
+        onTokenNearExpiration();
       }
     } catch (error) {
       console.error('Error verifying token expiration:', error);

--- a/src/index.js
+++ b/src/index.js
@@ -2,4 +2,5 @@ export {getAuthData} from './utils/oauth';
 export * from './useOauthData';
 export * from './utils/getUserInfo';
 export * from './utils/getAccessToken';
+export * from './WithTokensExpirationAccess';
 export {default} from './Provider';

--- a/src/index.js
+++ b/src/index.js
@@ -2,5 +2,5 @@ export {getAuthData} from './utils/oauth';
 export * from './useOauthData';
 export * from './utils/getUserInfo';
 export * from './utils/getAccessToken';
-export * from './WithTokensExpirationAccess';
+export * from './withTokensExpirationAccess';
 export {default} from './Provider';

--- a/src/withTokensExpirationAccess.js
+++ b/src/withTokensExpirationAccess.js
@@ -33,7 +33,7 @@ const isTokenNearExpiration = (expirationTime, thresholdInMinutes) => {
  *
  * @return {React.Component} The wrapped component.
  */
-export const WithTokensExpirationAccess = (Component, config = {}) => (
+export const withTokensExpirationAccess = (Component, config = {}) => (
   props,
 ) => {
   const {handleLogout: logout} = useOauthData();
@@ -48,15 +48,16 @@ export const WithTokensExpirationAccess = (Component, config = {}) => (
     try {
       const {expiration} = await getTokensCache();
       const isExpired = isTokenExpired(expiration);
-      const isNearExpiration = isTokenNearExpiration(
-        expiration,
-        minimumTokenExpirationTime,
-      );
 
       if (isExpired) {
         onTokenExpired();
         return logout();
       }
+
+      const isNearExpiration = isTokenNearExpiration(
+        expiration,
+        minimumTokenExpirationTime,
+      );
 
       if (isNearExpiration) {
         return onTokenNearExpiration();

--- a/test/WithTokensExpirationAccess.test.js
+++ b/test/WithTokensExpirationAccess.test.js
@@ -1,7 +1,7 @@
 import 'react-native';
 import React from 'react';
 import renderer, {act} from 'react-test-renderer';
-import {WithTokensExpirationAccess} from '../src';
+import {withTokensExpirationAccess} from '../src';
 import {getTokensCache} from '../src/utils/oauth';
 import {useOauthData} from '../src/useOauthData';
 
@@ -19,7 +19,7 @@ const mockOnTokenExpired = jest.fn();
 
 const MockComponent = () => <></>;
 
-describe('WithTokensExpirationAccess', () => {
+describe('withTokensExpirationAccess', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     jest.useFakeTimers();
@@ -40,7 +40,7 @@ describe('WithTokensExpirationAccess', () => {
 
     let tree;
     await act(async () => {
-      const WrappedComponent = WithTokensExpirationAccess(MockComponent);
+      const WrappedComponent = withTokensExpirationAccess(MockComponent);
 
       tree = renderer.create(<WrappedComponent />);
     });
@@ -54,7 +54,7 @@ describe('WithTokensExpirationAccess', () => {
     });
 
     await act(async () => {
-      const WrappedComponent = WithTokensExpirationAccess(MockComponent, {
+      const WrappedComponent = withTokensExpirationAccess(MockComponent, {
         onTokenNearExpiration: mockOnTokenNearExpiration,
       });
 
@@ -71,7 +71,7 @@ describe('WithTokensExpirationAccess', () => {
     });
 
     await act(async () => {
-      const WrappedComponent = WithTokensExpirationAccess(MockComponent, {});
+      const WrappedComponent = withTokensExpirationAccess(MockComponent, {});
 
       renderer.create(<WrappedComponent />);
     });
@@ -86,7 +86,7 @@ describe('WithTokensExpirationAccess', () => {
     });
 
     await act(async () => {
-      const WrappedComponent = WithTokensExpirationAccess(MockComponent, {
+      const WrappedComponent = withTokensExpirationAccess(MockComponent, {
         onTokenExpired: mockOnTokenExpired,
       });
 
@@ -103,7 +103,7 @@ describe('WithTokensExpirationAccess', () => {
     });
 
     await act(async () => {
-      const WrappedComponent = WithTokensExpirationAccess(MockComponent, {
+      const WrappedComponent = withTokensExpirationAccess(MockComponent, {
         minimumTokenExpirationTime: 120,
         onTokenNearExpiration: mockOnTokenNearExpiration,
       });
@@ -121,7 +121,7 @@ describe('WithTokensExpirationAccess', () => {
     });
 
     await act(async () => {
-      const WrappedComponent = WithTokensExpirationAccess(MockComponent, {
+      const WrappedComponent = withTokensExpirationAccess(MockComponent, {
         minimumTokenExpirationTime: 120,
       });
 
@@ -140,7 +140,7 @@ describe('WithTokensExpirationAccess', () => {
     getTokensCache.mockRejectedValue(new Error('Token cache error'));
 
     await act(async () => {
-      const WrappedComponent = WithTokensExpirationAccess(MockComponent, {
+      const WrappedComponent = withTokensExpirationAccess(MockComponent, {
         minimumTokenExpirationTime: 120,
       });
 

--- a/test/WithTokensExpirationAccess.test.js
+++ b/test/WithTokensExpirationAccess.test.js
@@ -1,0 +1,120 @@
+import 'react-native';
+import React from 'react';
+import renderer, {act} from 'react-test-renderer';
+import {WithTokensExpirationAccess} from '../src';
+import {getTokensCache} from '../src/utils/oauth';
+import {useOauthData} from '../src/useOauthData';
+
+jest.mock('../src/utils/oauth', () => ({
+  getTokensCache: jest.fn(),
+}));
+
+jest.mock('../src/useOauthData', () => ({
+  useOauthData: jest.fn(),
+}));
+
+const mockLogout = jest.fn();
+const mockCallback = jest.fn();
+
+const MockComponent = () => <></>;
+
+describe('WithTokensExpirationAccess', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    useOauthData.mockReturnValue({
+      handleLogout: mockLogout,
+    });
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders the wrapped component correctly without config', async () => {
+    getTokensCache.mockResolvedValue({
+      expiration: Date.now() + 10 * 60 * 1000,
+    });
+
+    let tree;
+    await act(async () => {
+      const WrappedComponent = WithTokensExpirationAccess(MockComponent);
+
+      tree = renderer.create(<WrappedComponent />);
+    });
+
+    expect(tree.toJSON()).toBeNull();
+  });
+
+  it('does NOT execute callback or logout if token expiration is far away', async () => {
+    getTokensCache.mockResolvedValue({
+      expiration: Date.now() + 3 * 60 * 60 * 1000,
+    });
+
+    await act(async () => {
+      const WrappedComponent = WithTokensExpirationAccess(MockComponent, {
+        minimumTokenExpirationTime: 120,
+        callback: mockCallback,
+      });
+
+      renderer.create(<WrappedComponent />);
+    });
+
+    expect(mockCallback).not.toHaveBeenCalled();
+    expect(mockLogout).not.toHaveBeenCalled();
+  });
+
+  it('executes callback and logouts when token is about to expire without minimumTokenExpirationTime', async () => {
+    getTokensCache.mockResolvedValue({
+      expiration: Date.now() + 1000,
+    });
+
+    await act(async () => {
+      const WrappedComponent = WithTokensExpirationAccess(MockComponent, {
+        callback: mockCallback,
+      });
+
+      renderer.create(<WrappedComponent />);
+    });
+
+    expect(mockCallback).toHaveBeenCalled();
+    expect(mockLogout).toHaveBeenCalled();
+  });
+
+  it('handles missing expiration timestamp', async () => {
+    getTokensCache.mockResolvedValue({
+      expiration: undefined,
+    });
+
+    await act(async () => {
+      const WrappedComponent = WithTokensExpirationAccess(MockComponent, {
+        minimumTokenExpirationTime: 120,
+        callback: mockCallback,
+      });
+
+      renderer.create(<WrappedComponent />);
+    });
+
+    expect(mockLogout).not.toHaveBeenCalled();
+    expect(mockCallback).not.toHaveBeenCalled();
+  });
+
+  it('calls `verifyExpiration` inside `useEffect` on mount and executes default callback', async () => {
+    getTokensCache.mockResolvedValue({
+      expiration: Date.now() + 10 * 60 * 1000,
+    });
+
+    await act(async () => {
+      const WrappedComponent = WithTokensExpirationAccess(MockComponent, {
+        minimumTokenExpirationTime: 120,
+      });
+
+      renderer.create(<WrappedComponent />);
+    });
+
+    jest.advanceTimersByTime(5000);
+
+    expect(getTokensCache).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
LINK DE TICKET: *

https://janiscommerce.atlassian.net/browse/APPSRN-360

DESCRIPCIÓN DEL REQUERIMIENTO: *

A partir del análisis del flujo de usuario logueado con tokens expirados, se determinó la creación de un nuevo HOC dentro del package de oauth-native, el mismo será util para controlar este flujo y encargarse de hacer que el usuario se vuelva a loguear y continúe con el flujo con normalidad

DESCRIPCIÓN DE LA SOLUCIÓN: *

Se creó el HOC WithTokensExpirationAccess, el cuál acepta un componente a renderizar y una config en la cuál se puede enviar el minimumTokenExpirationTime (el cuál por default será de 120 minutos), además de un callback a ejecutarse cuándo se cumpla este tiempo mencionado (onTokenNearExpiration) y otro callback para ejecutarse a la hora de expirar el token, antes de desloguearse (onTokenExpired). Este HOC se encarga de validar si se cumplió el tiempo en base a un cálculo entre el expiration (timeestamp obtenida a la hora de decodear el JWT y guardado en AsyncStorage) y el minimumTokenExpirationTime, es decir, si el expiration es el 13 de febrero a las 15:00 y el minimumTokenExpirationTime es de 120 minutos, a partir del 13 de febrero a la 13:00 se ejecutará el callback al ingresar al componente wrappeado en el HOC y luego se deslogueará al usuario.

CÓMO SE PUEDE PROBAR? *

Linkeandolo a algún repo y probando que funcione correctamente, ejecutandose el callback y el deslogueo cuándo corresponda, acá hay un ejemplo con de su implementación:

`
export default WithTokensExpirationAccess(InternalStop, {
	onTokenNearExpiration: () => Toast.show({text2: 'Token near expiration!', type: 'warning'}),
	onTokenExpired: () => console.log('Log out!'),
});
`

PRUEBA *

https://streamable.com/rkcuai

TENER EN CUENTA *

Hay que tener en cuenta que actualmente para el cálculo que verifica si se cumplió el tiempo para ejecutar el callback se utiliza el horario actual con el Date.now(), esto puede verse afectado si hay usuarios que tengan mal puesta la fecha del dispositivo, pero de momento se saldrá de esta forma y cómo evolutivo se implementará cierta api que brinda la propiedad expires-in, la cuál nos permitirá no utilizar el Date.now()