### PR TITLE
Implement flexible token expiration handling and export isTokenExpired

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ The method **getUserInfo** compared to **useOauthData.userData** is not context 
 
 ### withTokensExpirationAccess HOC
 
-HOC that provides automatic token expiration handling to wrapped components. It monitors the access token and refreshes it if it’s about to expire, ensuring the user session stays active without manual intervention as well as providing the option to alert the user some time before
+HOC that provides automatic token expiration handling to wrapped components. It monitors the access token and refreshes it if it's about to expire, ensuring the user session stays active without manual intervention as well as providing the option to alert the user some time before
 the token expires.
 
 ```js
@@ -129,8 +129,31 @@ export default withTokensExpirationAccess(SomeScreen, {
 
 **WithTokensExpirationAccess Configuration Options:**
 
-| config option              | Type     | Description                                                                                          |
-| -------------------------- | -------- | ---------------------------------------------------------------------------------------------------- |
-| minimumTokenExpirationTime | number   | Time in minutes before token expiration to trigger near-expiration callback. Default is 120 minutes. |
-| onTokenNearExpiration      | function | Callback function triggered when the token is near expiration.                                       |
-| onTokenExpired             | function | Callback function triggered when the token is expired. Also logs the user out.                       |
+| config option                          | Type     | Description                                                                                                                                                                                                                                                                                                                                                             |
+| -------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| minutesToConsiderTokenAsExpired        | number   | Number of minutes before the real expiration time at which the token should be considered expired. Defaults to 0, meaning expired at or after the exact expiration time. If the token is considered expired, `onTokenExpired` is called and the user is logged out.                                                                                                     |
+| minutesToConsiderTokenAsNearExpiration | number   | Number of minutes before the real expiration time to consider the token as near expiration. For `onTokenNearExpiration` to be triggered, this value must be a number and strictly greater than `minutesToConsiderTokenAsExpired`. Defaults to null, disabling the near expiration check. If the token is considered near expiration, `onTokenNearExpiration` is called. |
+| onTokenNearExpiration                  | function | Callback function triggered when the token is in the pre-expiration window (as defined by `minutesToConsiderTokenAsNearExpiration` and `minutesToConsiderTokenAsExpired`).                                                                                                                                                                                              |
+| onTokenExpired                         | function | Callback function triggered when the token is considered expired (as defined by `minutesToConsiderTokenAsExpired`). Also logs the user out.                                                                                                                                                                                                                             |
+
+### isTokenExpired method
+
+The method **isTokenExpired** checks if the current token has expired by retrieving the expiration time from the cache.
+
+```js
+// SomeComponent.js
+import {isTokenExpired} from '@janiscommerce/oauth-native';
+
+const SomeComponent = async () => {
+  const expired = await isTokenExpired();
+  if (expired) {
+    console.log('Token has expired');
+  } else {
+    console.log('Token is still valid');
+  }
+};
+```
+
+| state          | Type    | description                                                     |
+| -------------- | ------- | --------------------------------------------------------------- |
+| isTokenExpired | boolean | true if token is expired, false if it is not or an error occurs |

--- a/README.md
+++ b/README.md
@@ -144,13 +144,21 @@ The method **isTokenExpired** checks if the current token has expired by retriev
 // SomeComponent.js
 import {isTokenExpired} from '@janiscommerce/oauth-native';
 
-const SomeComponent = async () => {
-  const expired = await isTokenExpired();
-  if (expired) {
-    console.log('Token has expired');
-  } else {
-    console.log('Token is still valid');
-  }
++const SomeComponent = () => {
++  useEffect(() => {
++    const checkTokenExpiration = async () => {
++      const expired = await isTokenExpired();
++      if (expired) {
++        console.log('Token has expired');
++      } else {
++        console.log('Token is still valid');
++      }
++    };
++    checkTokenExpiration();
++  }, []);
++
++  return <View>...</View>;
+ };
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -142,23 +142,23 @@ The method **isTokenExpired** checks if the current token has expired by retriev
 
 ```js
 // SomeComponent.js
+import {useEffect} from 'react';
 import {isTokenExpired} from '@janiscommerce/oauth-native';
 
-+const SomeComponent = () => {
-+  useEffect(() => {
-+    const checkTokenExpiration = async () => {
-+      const expired = await isTokenExpired();
-+      if (expired) {
-+        console.log('Token has expired');
-+      } else {
-+        console.log('Token is still valid');
-+      }
-+    };
-+    checkTokenExpiration();
-+  }, []);
-+
-+  return <View>...</View>;
- };
+const SomeComponent = () => {
+  useEffect(() => {
+    const checkTokenExpiration = async () => {
+      const expired = await isTokenExpired();
+      if (expired) {
+        console.log('Token has expired');
+      } else {
+        console.log('Token is still valid');
+      }
+    };
+    checkTokenExpiration();
+  }, []);
+
+  return <View>...</View>;
 };
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,4 +3,5 @@ export * from './useOauthData';
 export * from './utils/getUserInfo';
 export * from './utils/getAccessToken';
 export * from './withTokensExpirationAccess';
+export {isTokenExpired} from './utils/oauth';
 export {default} from './Provider';

--- a/src/utils/oauth.js
+++ b/src/utils/oauth.js
@@ -180,3 +180,18 @@ export const clearAuthorizeTokens = async () => {
     return false;
   }
 };
+
+/**
+ * @name isTokenExpired
+ * @description Asynchronously checks if the token is expired by retrieving the expiration time from the cache.
+ * @async
+ * @returns {Promise<boolean>} - Resolves to true if the token is expired, false otherwise.
+ */
+export const isTokenExpired = async () => {
+  try {
+    const {expiration} = await getTokensCache();
+    return isExpired(expiration);
+  } catch (reason) {
+    return false;
+  }
+};

--- a/test/WithTokensExpirationAccess.test.js
+++ b/test/WithTokensExpirationAccess.test.js
@@ -22,179 +22,233 @@ const MockComponent = () => <></>;
 describe('withTokensExpirationAccess', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.useFakeTimers();
-
     useOauthData.mockReturnValue({
       handleLogout: mockLogout,
     });
   });
 
-  afterEach(() => {
-    jest.useRealTimers();
+  const renderHelper = async (config, expirationTime) => {
+    getTokensCache.mockResolvedValue({expiration: expirationTime});
+    const WrappedComponent = withTokensExpirationAccess(MockComponent, config);
+    await act(async () => {
+      renderer.create(<WrappedComponent />);
+    });
+  };
+
+  describe('Default Configuration (MTE=0, MTNE=null)', () => {
+    it('uses default value for config as it is not provided', async () => {
+      const expirationTime = Date.now() + 60 * 60 * 1000; // Expires in 1 hour
+      await renderHelper(undefined, expirationTime);
+      expect(mockOnTokenExpired).not.toHaveBeenCalled();
+      expect(mockOnTokenNearExpiration).not.toHaveBeenCalled();
+      expect(mockLogout).not.toHaveBeenCalled();
+    });
+
+    it('does not call any callbacks if token is valid', async () => {
+      const expirationTime = Date.now() + 60 * 60 * 1000; // Expires in 1 hour
+      await renderHelper({}, expirationTime);
+      expect(mockOnTokenExpired).not.toHaveBeenCalled();
+      expect(mockOnTokenNearExpiration).not.toHaveBeenCalled();
+      expect(mockLogout).not.toHaveBeenCalled();
+    });
+
+    it('calls onTokenExpired (if provided) and logout if token is at exact expiration point', async () => {
+      const expirationTime = Date.now(); // Expires now
+      await renderHelper({onTokenExpired: mockOnTokenExpired}, expirationTime);
+      expect(mockOnTokenExpired).toHaveBeenCalled();
+      expect(mockLogout).toHaveBeenCalled();
+      expect(mockOnTokenNearExpiration).not.toHaveBeenCalled();
+    });
+
+    it('calls logout (but not external onTokenExpired mock) if token is at exact expiration and no callback provided', async () => {
+      const expirationTime = Date.now(); // Expires now
+      await renderHelper({}, expirationTime);
+      expect(mockOnTokenExpired).not.toHaveBeenCalled(); // External mock not called
+      expect(mockLogout).toHaveBeenCalled();
+      expect(mockOnTokenNearExpiration).not.toHaveBeenCalled();
+    });
+
+    it('calls onTokenExpired (if provided) and logout if token is already past expiration', async () => {
+      const expirationTime = Date.now() - 10 * 60 * 1000; // Expired 10 minutes ago
+      await renderHelper({onTokenExpired: mockOnTokenExpired}, expirationTime);
+      expect(mockOnTokenExpired).toHaveBeenCalled();
+      expect(mockLogout).toHaveBeenCalled();
+      expect(mockOnTokenNearExpiration).not.toHaveBeenCalled();
+    });
   });
 
-  it('renders the wrapped component correctly without config', async () => {
-    getTokensCache.mockResolvedValue({
-      expiration: Date.now() + 10 * 60 * 1000,
+  describe('Custom MTE (minutesToConsiderTokenAsExpired > 0), MTNE is null', () => {
+    const MTE = 10; // Consider expired 10 minutes before actual expiration
+    it('does not call callbacks if token is valid and before MTE threshold', async () => {
+      const expirationTime = Date.now() + (MTE + 5) * 60 * 1000; // Expires in 15 minutes
+      await renderHelper(
+        {minutesToConsiderTokenAsExpired: MTE},
+        expirationTime,
+      );
+      expect(mockOnTokenExpired).not.toHaveBeenCalled();
+      expect(mockOnTokenNearExpiration).not.toHaveBeenCalled();
+      expect(mockLogout).not.toHaveBeenCalled();
     });
 
-    let tree;
-    await act(async () => {
-      const WrappedComponent = withTokensExpirationAccess(MockComponent);
-
-      tree = renderer.create(<WrappedComponent />);
+    it('calls onTokenExpired (if provided) and logout if token is at MTE threshold', async () => {
+      const expirationTime = Date.now() + MTE * 60 * 1000; // Expires in 10 minutes (at threshold)
+      await renderHelper(
+        {
+          minutesToConsiderTokenAsExpired: MTE,
+          onTokenExpired: mockOnTokenExpired,
+        },
+        expirationTime,
+      );
+      expect(mockOnTokenExpired).toHaveBeenCalled();
+      expect(mockLogout).toHaveBeenCalled();
+      expect(mockOnTokenNearExpiration).not.toHaveBeenCalled();
     });
 
-    expect(tree.toJSON()).toBeNull();
+    it('calls onTokenExpired (if provided) and logout if token is past MTE threshold but before actual expiration', async () => {
+      const expirationTime = Date.now() + (MTE - 5) * 60 * 1000; // Expires in 5 minutes (past threshold)
+      await renderHelper(
+        {
+          minutesToConsiderTokenAsExpired: MTE,
+          onTokenExpired: mockOnTokenExpired,
+        },
+        expirationTime,
+      );
+      expect(mockOnTokenExpired).toHaveBeenCalled();
+      expect(mockLogout).toHaveBeenCalled();
+      expect(mockOnTokenNearExpiration).not.toHaveBeenCalled();
+    });
   });
 
-  it('executes onTokenNearExpiration when token is near expiration but not yet expired', async () => {
-    const minutesToConsiderTokenAsExpired = 10;
-    const minutesToConsiderTokenAsNearExpiration = 5;
+  describe('MTNE > MTE (Near Expiration Active)', () => {
+    const MTE = 5;
+    const MTNE = 30;
+    const config = {
+      minutesToConsiderTokenAsExpired: MTE,
+      minutesToConsiderTokenAsNearExpiration: MTNE,
+      onTokenNearExpiration: mockOnTokenNearExpiration,
+      onTokenExpired: mockOnTokenExpired,
+    };
 
-    const expiration =
-      Date.now() +
-      (minutesToConsiderTokenAsExpired +
-        minutesToConsiderTokenAsNearExpiration -
-        1) *
-        60 *
-        1000;
-
-    getTokensCache.mockResolvedValue({
-      expiration,
+    it('does not call callbacks if token is valid and before MTNE window', async () => {
+      const expirationTime = Date.now() + (MTNE + 5) * 60 * 1000; // Expires in 35 minutes
+      await renderHelper(config, expirationTime);
+      expect(mockOnTokenNearExpiration).not.toHaveBeenCalled();
+      expect(mockOnTokenExpired).not.toHaveBeenCalled();
+      expect(mockLogout).not.toHaveBeenCalled();
     });
 
-    await act(async () => {
-      const WrappedComponent = withTokensExpirationAccess(MockComponent, {
-        minutesToConsiderTokenAsExpired,
-        minutesToConsiderTokenAsNearExpiration,
+    it('calls onTokenNearExpiration if token is entering MTNE window', async () => {
+      const expirationTime = Date.now() + MTNE * 60 * 1000; // Expires in 30 minutes
+      await renderHelper(config, expirationTime);
+      expect(mockOnTokenNearExpiration).toHaveBeenCalled();
+      expect(mockOnTokenExpired).not.toHaveBeenCalled();
+      expect(mockLogout).not.toHaveBeenCalled();
+    });
+
+    it('calls onTokenNearExpiration if token is in the middle of MTNE window', async () => {
+      const expirationTime = Date.now() + (MTE + (MTNE - MTE) / 2) * 60 * 1000; // Expires in 17.5 mins
+      await renderHelper(config, expirationTime);
+      expect(mockOnTokenNearExpiration).toHaveBeenCalled();
+      expect(mockOnTokenExpired).not.toHaveBeenCalled();
+      expect(mockLogout).not.toHaveBeenCalled();
+    });
+
+    it('calls onTokenExpired when token reaches MTE threshold (exiting MTNE window)', async () => {
+      const expirationTime = Date.now() + MTE * 60 * 1000; // Expires in 5 minutes
+      await renderHelper(config, expirationTime);
+      expect(mockOnTokenExpired).toHaveBeenCalled();
+      expect(mockLogout).toHaveBeenCalled();
+      expect(mockOnTokenNearExpiration).not.toHaveBeenCalled(); // onTokenExpired takes precedence
+    });
+
+    it('does NOT call external mockOnTokenNearExpiration if no callback is passed, even if near expiration conditions met', async () => {
+      const noCallbackConfig = {
+        minutesToConsiderTokenAsExpired: MTE,
+        minutesToConsiderTokenAsNearExpiration: MTNE,
+        // onTokenNearExpiration is NOT provided
+      };
+      const expirationTime = Date.now() + (MTE + (MTNE - MTE) / 2) * 60 * 1000; // Expires in 17.5 mins (in near window)
+      await renderHelper(noCallbackConfig, expirationTime);
+      expect(mockOnTokenNearExpiration).not.toHaveBeenCalled(); // The global mock
+      expect(mockOnTokenExpired).not.toHaveBeenCalled();
+      expect(mockLogout).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('MTNE Invalid (e.g., MTNE <= MTE or not a number)', () => {
+    it('does not call onTokenNearExpiration if mockOnTokenNearExpiration <= minutesToConsiderTokenAsExpired', async () => {
+      const MTE = 30;
+      const MTNE = 15;
+      const config = {
+        minutesToConsiderTokenAsExpired: MTE,
+        minutesToConsiderTokenAsNearExpiration: MTNE,
         onTokenNearExpiration: mockOnTokenNearExpiration,
-      });
-
-      renderer.create(<WrappedComponent />);
-    });
-
-    expect(mockLogout).not.toHaveBeenCalled();
-    expect(mockOnTokenNearExpiration).toHaveBeenCalled();
-  });
-
-  it('executes onTokenNearExpiration when token is near expiration but not yet expired and there is no callback', async () => {
-    const minutesToConsiderTokenAsExpired = 10;
-    const minutesToConsiderTokenAsNearExpiration = 5;
-
-    const expiration =
-      Date.now() +
-      (minutesToConsiderTokenAsExpired +
-        minutesToConsiderTokenAsNearExpiration -
-        1) *
-        60 *
-        1000;
-
-    getTokensCache.mockResolvedValue({
-      expiration,
-    });
-
-    await act(async () => {
-      const WrappedComponent = withTokensExpirationAccess(MockComponent, {
-        minutesToConsiderTokenAsExpired,
-        minutesToConsiderTokenAsNearExpiration,
-      });
-
-      renderer.create(<WrappedComponent />);
-    });
-
-    expect(mockLogout).not.toHaveBeenCalled();
-    expect(mockOnTokenNearExpiration).toHaveBeenCalledTimes(0);
-  });
-
-  it('does not execute onTokenExpired as there is no callback and logouts when token has expired', async () => {
-    getTokensCache.mockResolvedValue({
-      expiration: Date.now(),
-    });
-
-    await act(async () => {
-      const WrappedComponent = withTokensExpirationAccess(MockComponent, {});
-
-      renderer.create(<WrappedComponent />);
-    });
-
-    expect(mockOnTokenExpired).not.toHaveBeenCalled();
-    expect(mockLogout).toHaveBeenCalled();
-  });
-
-  it('executes onTokenExpired and logouts when token has expired', async () => {
-    getTokensCache.mockResolvedValue({
-      expiration: Date.now(),
-    });
-
-    await act(async () => {
-      const WrappedComponent = withTokensExpirationAccess(MockComponent, {
         onTokenExpired: mockOnTokenExpired,
-      });
-
-      renderer.create(<WrappedComponent />);
+      };
+      const expirationTime = Date.now() + (MTNE + 5) * 60 * 1000;
+      await renderHelper(config, expirationTime);
+      expect(mockOnTokenNearExpiration).not.toHaveBeenCalled();
+      expect(mockOnTokenExpired).toHaveBeenCalled();
+      expect(mockLogout).toHaveBeenCalled();
     });
 
-    expect(mockOnTokenExpired).toHaveBeenCalled();
-    expect(mockLogout).toHaveBeenCalled();
-  });
-
-  it('handles missing expiration timestamp', async () => {
-    getTokensCache.mockResolvedValue({
-      expiration: undefined,
-    });
-
-    await act(async () => {
-      const WrappedComponent = withTokensExpirationAccess(MockComponent, {
-        minimumTokenExpirationTime: 120,
+    it('does not call onTokenNearExpiration if MTNE is not a number', async () => {
+      const MTE = 5;
+      const config = {
+        minutesToConsiderTokenAsExpired: MTE,
+        minutesToConsiderTokenAsNearExpiration: 'abc', // Not a number
         onTokenNearExpiration: mockOnTokenNearExpiration,
-      });
-
-      renderer.create(<WrappedComponent />);
+      };
+      const expirationTime = Date.now() + 10 * 60 * 1000; // Expires in 10 minutes
+      await renderHelper(config, expirationTime);
+      expect(mockOnTokenNearExpiration).not.toHaveBeenCalled();
+      expect(mockOnTokenExpired).not.toHaveBeenCalled();
+      expect(mockLogout).not.toHaveBeenCalled();
     });
-
-    expect(mockLogout).not.toHaveBeenCalled();
-    expect(mockOnTokenNearExpiration).not.toHaveBeenCalled();
   });
 
-  it('calls `checkExpiration` inside `useEffect` on mount and executes default callback', async () => {
-    getTokensCache.mockResolvedValue({
-      expiration: Date.now() + 10 * 60 * 1000,
+  describe('Edge Cases', () => {
+    it('does not call callbacks or logout if expiration time is undefined', async () => {
+      // With undefined expiration, calculations involving it will result in NaN.
+      // Conditions like `currentTime >= NaN` are false.
+      await renderHelper(
+        {
+          onTokenExpired: mockOnTokenExpired,
+          onTokenNearExpiration: mockOnTokenNearExpiration,
+        },
+        undefined,
+      );
+      expect(mockOnTokenExpired).not.toHaveBeenCalled();
+      expect(mockOnTokenNearExpiration).not.toHaveBeenCalled();
+      expect(mockLogout).not.toHaveBeenCalled();
     });
 
-    await act(async () => {
-      const WrappedComponent = withTokensExpirationAccess(MockComponent, {
-        minimumTokenExpirationTime: 120,
+    it('handles error from getTokensCache and calls console.error', async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      getTokensCache.mockRejectedValue(new Error('Token cache error'));
+
+      const WrappedComponent = withTokensExpirationAccess(MockComponent, {});
+      await act(async () => {
+        renderer.create(<WrappedComponent />);
       });
 
-      renderer.create(<WrappedComponent />);
+      expect(mockOnTokenExpired).not.toHaveBeenCalled();
+      expect(mockOnTokenNearExpiration).not.toHaveBeenCalled();
+      expect(mockLogout).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Error verifying token expiration:',
+        expect.any(Error),
+      );
+      consoleErrorSpy.mockRestore();
     });
 
-    jest.advanceTimersByTime(5000);
-
-    expect(getTokensCache).toHaveBeenCalledTimes(1);
-  });
-
-  it('handles error when verifying token expiration', async () => {
-    const consoleErrorSpy = jest
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
-    getTokensCache.mockRejectedValue(new Error('Token cache error'));
-
-    await act(async () => {
-      const WrappedComponent = withTokensExpirationAccess(MockComponent, {
-        minimumTokenExpirationTime: 120,
-      });
-
-      renderer.create(<WrappedComponent />);
+    it('calls getTokensCache on mount', async () => {
+      // This test primarily ensures the effect hook runs and initiates the check.
+      const expirationTime = Date.now() + 60 * 60 * 1000; // Valid token
+      await renderHelper({}, expirationTime);
+      expect(getTokensCache).toHaveBeenCalledTimes(1);
     });
-
-    expect(mockLogout).not.toHaveBeenCalled();
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'Error verifying token expiration:',
-      expect.any(Error),
-    );
-
-    consoleErrorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
LINK DE TICKET: *

https://janiscommerce.atlassian.net/browse/APPSRN-376

DESCRIPCIÓN DEL REQUERIMIENTO: *

Se identificó que la manera en la que se hacen uso de las props se puede prestar a confusión y no son del todo intuitivas, esto hace que se pueda llegar a perder tiempo ingresando a la definición del HOC para ver cómo funciona realmente, se identificó:

Una manera anti intuitiva de utilizar minutesToConsiderTokenAsNearExpiration:

Actualmente la prop realiza el cálculo de cuando un token es considerado como nearExpiration en base al cálculo entre minutesToConsiderTokenAsExpired y la expiración real del token, esto genera una confusión ya que si minutesToConsiderTokenAsNearExpiration tiene un valor de 120 y minutesToConsiderTokenAsExpired también, se estará ejecutando onTokenNearExpiration 4 horas antes de la expiración real y onTokenExpired 2 horas antes de la expiración real, lo que se presta a confusión

Se puede llegar a generar confusión con minutesToConsiderTokenAsExpired cuando el mismo es 0

Cuando está prop es igual a 0, lo que se va a terminar tomando como expiración es el tiempo real de expiración de oauth, esto puede generar la confusión de pensar que al ser 0 directamente está expirado el token, cuando no es así

A su vez, se identificó que para la implementación del HOC se requiere de una util para saber cuando el token está expirado realmente, esto para hacer uso de la misma a la hora de finalizar los distintos flujos, antes de pasar a pantallas que requieren de internet, para evitar el error de error getting user info.

DESCRIPCIÓN DE LA SOLUCIÓN: *

Por el lado de los ajustes que se realizaron en el HOC:

Se estuvo modificando la prop minutesToConsiderTokenAsNearExpiration para que:

- Por default sea null
- Obligatoriamente deba ser un número y mayor a minutesToConsiderTokenAsExpired para que se intente ejecutar onTokenNearExpiration
- Haga uso del tiempo real de expiración, no dependa del cálculo entre minutesToConsiderTokenAsExpired y el tiempo real

En tanto al comportamiento de minutesToConsiderTokenAsExpired:

- Pasará a ser por default 0

Al respecto de la util que se debe generar para la implementación correcta del HOC y el deslogueo al encontrarse cerca de finalizar los flujos:

- La misma se llamará isTokenExpired
- Tomará el token de AsyncStorage
- Hará uso de la función isExpired

CÓMO SE PUEDE PROBAR? *

<p>La idea de este desarrollo será que se pueda hacer uso de este nuevo HOC de la forma más sencilla posible para definir en ciertas pantallas que si el usuario se encuentra con los tokens de su sesión vencidos o próximos a vencer se lo alerte o se lo desloguee en caso de ya tener la sesión vencida.</p>
<p>Para poder probar el HOC de una forma sencilla, se puede hacer uso de la branch <a href="https://bitbucket.org/fizzmodsrl/janis-picking-app/branch/JPRN-2036-implementaci%C3%B3n-de-desloguear-usuario-al-vencer-tokens"><a href="https://bitbucket.org/fizzmodsrl/janis-picking-app/branch/JPRN-2036-implementaci%C3%B3n-de-desloguear-usuario-al-vencer-tokens">https://bitbucket.org/fizzmodsrl/janis-picking-app/branch/JPRN-2036-implementación-de-desloguear-usuario-al-vencer-tokens</a></a>, la cuál ya cuenta con el HOC implementado en los listados de todos los flujos y la util getTokenExipirationConfig, la cuál usaremos para settear las props de <code>minutesToConsiderTokenAsExpired</code>, <code>minutesToConsiderTokenAsNearExpiration</code>, <code>onTokenExpired</code> y <code>onTokenNearExpiration</code> , mientras que la <code>expiration</code> que se va a estar nombrando en la parte de configuración de la tabla de casos hará alusión a la expiración REAL de oauth-native, es decir, la que se guarda en AsyncStorage, para poder modificarla nos podemos dirigir a node_modules/@janiscommerce/oauth-native/src/utils/oauth.js y allí modificar la función userAuthorize de la siguiente manera:</p>
<pre><code class="language-jsx">export const userAuthorize = async (config = {}) =&gt; {
  try {
    if (!config || !Object.keys(config).length)
      throw new Error('config param is required');

    const authState = await authorize(config);

		const now = new Date();

    const accessTokenExpirationDate = new Date(now.getTime() + {minutos dentro de los que expirará el token} * 60 * 1000);

	  const newState = {...authState, accessTokenExpirationDate};
    storeTokensCache(newState);

    return authState;
  } catch (reason) {
    return Promise.reject(reason);
  }
};

</code></pre>
<p>Ya con eso modificado, al desloguearnos y volvernos a loguear en la App se actualizará la expiración a la cuál setteamos en userAuthorize.</p>

<table>
  <thead>
    <tr>
      <th>Caso</th>
      <th>Configuración (<code>getTokenExipirationConfig</code>)</th>
      <th>Resultado Esperado</th>
      <th>Probado</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Token muy válido</td>
      <td><pre>minutesToConsiderTokenAsExpired: 0
minutesToConsiderTokenAsNearExpiration: null
expiration: 60 minutos</pre></td>
      <td>
        <ul>
          <li>No se ejecuta <code>onTokenNearExpiration</code></li>
          <li>No se ejecuta <code>onTokenExpired</code></li>
          <li>No se desloguea</li>
        </ul>
      </td>
      <td>✅</td>
    </tr>
    <tr>
      <td>Token en punto de expiración real</td>
      <td><pre>minutesToConsiderTokenAsExpired: 0
minutesToConsiderTokenAsNearExpiration: null
expiration: 0 minutos</pre></td>
      <td>
        <ul>
          <li>No se ejecuta <code>onTokenNearExpiration</code></li>
          <li>Se ejecuta <code>onTokenExpired</code></li>
          <li>Se desloguea</li>
        </ul>
      </td>
      <td>✅</td>
    </tr>
    <tr>
      <td>Token ya expirado</td>
      <td><pre>minutesToConsiderTokenAsExpired: 0
minutesToConsiderTokenAsNearExpiration: null
expiration: -1 minutos</pre></td>
      <td>
        <ul>
          <li>No se ejecuta <code>onTokenNearExpiration</code></li>
          <li>Se ejecuta <code>onTokenExpired</code></li>
          <li>Se desloguea</li>
        </ul>
      </td>
      <td>✅</td>
    </tr>
    <tr>
      <td>Token justo antes del umbral de <code>minutesToConsiderTokenAsExpired</code></td>
      <td><pre>minutesToConsiderTokenAsExpired: 10
minutesToConsiderTokenAsNearExpiration: null
expiration: 11 minutos</pre></td>
      <td>
        <ul>
          <li>No se ejecuta <code>onTokenNearExpiration</code></li>
          <li>No se ejecuta <code>onTokenExpired</code></li>
          <li>No se desloguea</li>
        </ul>
      </td>
      <td>✅</td>
    </tr>
    <tr>
      <td>Token en umbral de expiración <code>minutesToConsiderTokenAsExpired</code></td>
      <td><pre>minutesToConsiderTokenAsExpired: 10
minutesToConsiderTokenAsNearExpiration: null
expiration: 10 minutos</pre></td>
      <td>
        <ul>
          <li>No se ejecuta <code>onTokenNearExpiration</code></li>
          <li>Se ejecuta <code>onTokenExpired</code></li>
          <li>Se desloguea</li>
        </ul>
      </td>
      <td>✅</td>
    </tr>
    <tr>
      <td>Token antes de ventana <code>minutesToConsiderTokenAsNearExpiration</code></td>
      <td><pre>minutesToConsiderTokenAsExpired: 5
minutesToConsiderTokenAsNearExpiration: 30
expiration: 35 minutos</pre></td>
      <td>
        <ul>
          <li>No se ejecuta <code>onTokenNearExpiration</code></li>
          <li>No se ejecuta <code>onTokenExpired</code></li>
          <li>No se desloguea</li>
        </ul>
      </td>
      <td>✅</td>
    </tr>
    <tr>
      <td>Token entrando en ventana <code>minutesToConsiderTokenAsNearExpiration</code></td>
      <td><pre>minutesToConsiderTokenAsExpired: 5
minutesToConsiderTokenAsNearExpiration: 30
expiration: 30 minutos</pre></td>
      <td>
        <ul>
          <li>Se ejecuta <code>onTokenNearExpiration</code></li>
          <li>No se ejecuta <code>onTokenExpired</code></li>
          <li>No se desloguea</li>
        </ul>
      </td>
      <td>✅</td>
    </tr>
    <tr>
      <td>Token en medio de ventana <code>minutesToConsiderTokenAsNearExpiration</code></td>
      <td><pre>minutesToConsiderTokenAsExpired: 5
minutesToConsiderTokenAsNearExpiration: 30
expiration: 15 minutos</pre></td>
      <td>
        <ul>
          <li>Se ejecuta <code>onTokenNearExpiration</code></li>
          <li>No se ejecuta <code>onTokenExpired</code></li>
          <li>No se desloguea</li>
        </ul>
      </td>
      <td>✅</td>
    </tr>
    <tr>
      <td>Token saliendo de <code>minutesToConsiderTokenAsNearExpiration</code> / entrando en <code>minutesToConsiderTokenAsExpired</code></td>
      <td><pre>minutesToConsiderTokenAsExpired: 5
minutesToConsiderTokenAsNearExpiration: 30
expiration: 5 minutos</pre></td>
      <td>
        <ul>
          <li>No se ejecuta <code>onTokenNearExpiration</code></li>
          <li>Se ejecuta <code>onTokenExpired</code></li>
          <li>Se desloguea</li>
        </ul>
      </td>
      <td>✅</td>
    </tr>
    <tr>
      <td>Token después de umbral <code>minutesToConsiderTokenAsExpired</code></td>
      <td><pre>minutesToConsiderTokenAsExpired: 5
minutesToConsiderTokenAsNearExpiration: 30
expiration: -1 minutos</pre></td>
      <td>
        <ul>
          <li>No se ejecuta <code>onTokenNearExpiration</code></li>
          <li>Se ejecuta <code>onTokenExpired</code></li>
          <li>Se desloguea</li>
        </ul>
      </td>
      <td>✅</td>
    </tr>
    <tr>
      <td><code>minutesToConsiderTokenAsNearExpiration</code> inválido: Token en ventana donde estaría <code>minutesToConsiderTokenAsNearExpiration</code></td>
      <td><pre>minutesToConsiderTokenAsExpired: 30
minutesToConsiderTokenAsNearExpiration: 15
expiration: 20 minutos</pre></td>
      <td>
        <ul>
          <li>No se ejecuta <code>onTokenNearExpiration</code></li>
          <li>Se ejecuta <code>onTokenExpired</code></li>
          <li>Se desloguea</li>
        </ul>
      </td>
      <td>✅</td>
    </tr>
  </tbody>
</table>

---

Prueba de util

Para probar la nueva util isTokenExpired bastará con modificar nuevamente cómo en el paso anterior la expiración real para que el token expire en un minuto o menos, esperar a que expire, y en una pantalla dónde no se encuentre implementado el HOC hacer uso de la misma de la siguiente manera:

`
const fetchIsTokenExpired = async () => {
		const isTokenExpiredValue = await isTokenExpired();
		console.log('isTokenExpiredValue :>> ', isTokenExpiredValue);
	};

	useEffect(() => {
		fetchIsTokenExpired();
	}, []);
`

De esta manera el valor que se console loguee debería ser true, si el token no está expirado debería ser false.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a method to asynchronously check if the current token is expired.
- **Documentation**
  - Updated and clarified token expiration configuration options and callbacks.
  - Added usage examples and state description for the new expiration check method.
- **Tests**
  - Expanded and reorganized tests covering token expiration logic and the new expiration check method.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->