### PR TITLE
Refactor: Update token check to useFocusEffect and adapt tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "react": ">= 16.13.1",
     "react-native": ">= 0.63.4",
     "react-native-app-auth": "^6.2.0",
-    "react-native-inappbrowser-reborn": "^3.5.1"
+    "react-native-inappbrowser-reborn": "^3.5.1",
+    "@react-navigation/native": "^6.1.6"
   },
   "jest": {
     "preset": "react-native"

--- a/src/withTokensExpirationAccess.js
+++ b/src/withTokensExpirationAccess.js
@@ -1,4 +1,5 @@
-import React, {useEffect} from 'react';
+import React, {useCallback, useState} from 'react';
+import {useFocusEffect} from '@react-navigation/native';
 import {getTokensCache} from './utils/oauth';
 import {useOauthData} from './useOauthData';
 
@@ -38,6 +39,7 @@ export const withTokensExpirationAccess = (Component, config = {}) => (
   props,
 ) => {
   const {handleLogout: logout} = useOauthData();
+  const [isCheckingToken, setIsCheckingToken] = useState(true);
 
   const {
     minutesToConsiderTokenAsNearExpiration = null,
@@ -84,13 +86,22 @@ export const withTokensExpirationAccess = (Component, config = {}) => (
 
       return null;
     } catch (error) {
-      return console.error('Error verifying token expiration:', error);
+      console.error('Error verifying token expiration:', error);
+      return null;
+    } finally {
+      setIsCheckingToken(false);
     }
   };
 
-  useEffect(() => {
-    checkTokenExpiration();
-  }, []);
+  useFocusEffect(
+    useCallback(() => {
+      checkTokenExpiration();
+    }, [checkTokenExpiration]),
+  );
+
+  if (isCheckingToken) {
+    return null;
+  }
 
   return <Component {...props} />;
 };

--- a/test/WithTokensExpirationAccess.test.js
+++ b/test/WithTokensExpirationAccess.test.js
@@ -13,6 +13,21 @@ jest.mock('../src/useOauthData', () => ({
   useOauthData: jest.fn(),
 }));
 
+// Add this mock for @react-navigation/native
+jest.mock('@react-navigation/native', () => {
+  const actualNav = jest.requireActual('@react-navigation/native');
+  const ActualReact = jest.requireActual('react'); // Use a different name to avoid conflict
+  return {
+    ...actualNav,
+    useFocusEffect: jest.fn((effect) => {
+      // Simulate running the effect once on mount for testing purposes
+      ActualReact.useEffect(() => {
+        effect();
+      }, []); // Empty dependency array to run only once
+    }),
+  };
+});
+
 const mockLogout = jest.fn();
 const mockOnTokenNearExpiration = jest.fn();
 const mockOnTokenExpired = jest.fn();


### PR DESCRIPTION
LINK DE TICKET: *

https://janiscommerce.atlassian.net/browse/APPSRN-380

DESCRIPCIÓN DEL REQUERIMIENTO: *

Tras pruebas con el componente withTokensExpirationAccess de oauth-native se encontraron dos problemas con el mismo. Por un lado, al volver a las pantallas a las que se estaba a partir del botón físico de Android o del botón de vuelta atrás de los Headers no se ejecuta la verificación de si el token está vencido o no. Por otro lado, también se encontró que en algunos casos se renderiza el componente que se le pasa al HOC cuándo aún no terminó la verificación de los tokens, lo que hace que se generen requests innecesarias en algunos momentos.

DESCRIPCIÓN DE LA SOLUCIÓN: *

Se deberá agregar react-navigation/native a las peer-dependencies del package

Se debe comenzar a usar el useFocusEffect de react navigation para que al volver a una pantalla con el HOC se verifiquen los tokens

Se empleará un useState para determinar cuándo se estan verificando los tokens, mientras esto pasa no se estará renderizando el componente pasado al HOC

CÓMO SE PUEDE PROBAR? *

Para poder probar el HOC de una forma sencilla, se puede hacer uso de la branch [https://bitbucket.org/fizzmodsrl/janis-picking-app/branch/JPRN-2036-implementación-de-desloguear-usuario-al-vencer-tokens](https://bitbucket.org/fizzmodsrl/janis-picking-app/branch/JPRN-2036-implementaci%C3%B3n-de-desloguear-usuario-al-vencer-tokens), la cuál ya cuenta con el HOC implementado en los listados de todos los flujos y la util getTokenExipirationConfig, la cuál usaremos para settear las props de minutesToConsiderTokenAsExpired, minutesToConsiderTokenAsNearExpiration, onTokenExpired y onTokenNearExpiration , mientras que la expiration que se va a estar nombrando en la parte de configuración de la tabla de casos hará alusión a la expiración REAL de oauth-native, es decir, la que se guarda en AsyncStorage, para poder modificarla nos podemos dirigir a node_modules/@janiscommerce/oauth-native/src/utils/oauth.js y allí modificar la función userAuthorize de la siguiente manera:

`
const authState = await authorize(config);

	const now = new Date();

const accessTokenExpirationDate = new Date(now.getTime() + {minutos dentro de los que expirará el token} * 60 * 1000);

  const newState = {...authState, accessTokenExpirationDate};
storeTokensCache(newState);

return authState;
`

Ya con eso modificado, al desloguearnos y volvernos a loguear en la App se actualizará la expiración a la cuál setteamos en userAuthorize.

Con esto hecho, deberemos probar dos casos:
- Al estar con los tokens vencidos y volver hacia atrás a una pantalla que cuenta con el HOC implementado, cómo por ejemplo, pasar de la pantalla de Listado de Sesiones a la Home, nos debe desloguear
- Que cuándo entramos a una pantalla que cuenta con el HOC por primera vez y con los tokens vencidos no se llegue a renderizar la pantalla, esto puede probarse entrando al Listado de Sesiones desde la Home
