### PR TITLE
Jdapp 1554 ajustar hoc de withtokensexpirationaccess

### DIFF
--- a/src/withTokensExpirationAccess.js
+++ b/src/withTokensExpirationAccess.js
@@ -77,6 +77,7 @@ export const withTokensExpirationAccess = (Component, config = {}) => (
         } finally {
           setIsLoading(false);
           logout();
+          hasRunTokenExpired.current = false;
         }
       }
 

--- a/src/withTokensExpirationAccess.js
+++ b/src/withTokensExpirationAccess.js
@@ -75,9 +75,9 @@ export const withTokensExpirationAccess = (Component, config = {}) => (
         } catch (error) {
           console.error('Error executing onTokenExpired callback:', error);
         } finally {
-          setIsLoading(false);
-          logout();
           hasRunTokenExpired.current = false;
+          logout();
+          setIsLoading(false);
         }
       }
 


### PR DESCRIPTION
## LINK DE TICKET: *
https://janiscommerce.atlassian.net/browse/JDAPP-1554

## DESCRIPCIÓN DEL REQUERIMIENTO: *
Se identificó durante la implementación de deslogueo por expiración de tokens que al desloguearse cuándo se vuelve a una pantalla, cómo por ejemplo si el usuario se encuentra en algún Listado, se le vencen los tokens dentro de esa pantalla y se vuelve a la pantalla Home previamente montada, se ejecutan funciones dentro de esa pantalla, cuándo en realidad esto no tendría que pasar debido a que se lo tiene que desloguear al usuario antes de que esto ocurra.

## DESCRIPCIÓN DE LA SOLUCIÓN: *
Se modificó el orden del bloque finally del HOC withTokensExpirationAccess para que, al volver a la pantalla en la que se encontraba el usuario, primero se desloguee correctamente y luego se settee el estado de carga, de esta manera evitando que se llamen funciones en la pantalla que se volvió

---

## ¿CÓMO SE PUEDE PROBAR? *

Se deberán seguir los siguientes pasos:

1. Dirigirse a la App de Orders e irse a la branch JPRN-2075 con el siguiente comando:
`git checkout JPRN-2075-implementar-desuscripción-de-push-al-desloguear`
2. Vincular esta branch del package de oauth-native con el repo de Orders
3. Dirigirse a .yalc/@janiscommerce/oauth-native/src/utils/oauth.js y modificar la util userAuthorize de la siguiente manera:
```
export const userAuthorize = async (config = {}) => {
  try {
    if (!config || !Object.keys(config).length)
      throw new Error('config param is required');

    const authState = await authorize(config);
    const now = new Date();
    const accessTokenExpirationDate = new Date(now.getTime() + 2 * 60 * 1000);
    const newState = {...authState, accessTokenExpirationDate};
    storeTokensCache(newState);

    return authState;
  } catch (reason) {
    return Promise.reject(reason);
  }
};
```
4. Modificar la util tokenExpirationConfig de la siguiente manera:
```
// istanbul ignore file

// istanbul ignore file

import React from 'react';
import {promiseWrapper} from '@janiscommerce/apps-helpers';
import {LAST_NAVIGATION_STATE_KEY, PERSISTENCE_KEY} from 'src/constants/navigationPersistence';
import getLastScreenName from 'src/utils/navigation/getLastScreenName';
import {LoadingFullScreen} from '@janiscommerce/ui-native';
import i18n from 'src/i18n';
import getItem from '../../asyncStorage/getItem';
import setItem from '../../asyncStorage/setItem';
import clearStateOnLogout from '../clearStateOnLogout';

const tokenExpirationConfig = {
	onTokenExpired: async () => {
		const [initialRoute, errorInitialRoute] = await promiseWrapper(getItem(PERSISTENCE_KEY));
		if (!initialRoute || errorInitialRoute) return;

		const screenName = getLastScreenName(JSON.parse(initialRoute));

		await setItem(LAST_NAVIGATION_STATE_KEY, JSON.parse(initialRoute));
		await clearStateOnLogout({screenName});
	},
	minutesToConsiderTokenAsExpired: 1,
	renderLoadingComponent: () => (
		<LoadingFullScreen isLoading text={i18n.t('appCommon.message.loggingOut')} />
	),
};

export default tokenExpirationConfig;

```
5. Luego, en la app de Orders, pasar por la Home, dirigirse a algún listado de cualquier flujo y esperar que expiren los tokens
6. Volver hacia atrás a la pantalla Home
7. Debe desloguear correctamente al usuario y no se debe generar ningún error de pickerData o userInfo
8. Al volver a iniciar sesión todo debe funcionar correctamente


## SCREENSHOTS:

## DATOS EXTRA A TENER EN CUENTA:

## CHANGELOG:
`-  Changed order of finally block on withTokensExpirationAccess as to prevent errors when re-rendering`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the handling of token expiration to ensure smoother logout and loading state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->