### PR TITLE
Added new isUserDev method

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,5 +3,5 @@ export * from './useOauthData';
 export * from './utils/getUserInfo';
 export * from './utils/getAccessToken';
 export * from './withTokensExpirationAccess';
-export {isTokenExpired} from './utils/oauth';
+export {isTokenExpired, isUserDev} from './utils/oauth';
 export {default} from './Provider';

--- a/src/utils/oauth.js
+++ b/src/utils/oauth.js
@@ -209,10 +209,10 @@ export const isTokenExpired = async () => {
 export const isUserDev = async () => {
   try {
     const {oauthTokens} = await getTokensCache();
-    const {idToken = ''} = oauthTokens || {};
+    const {idToken = ''} = oauthTokens ?? {};
     const decoded = jwtDecode(idToken);
-    return decoded?.isDev;
-  } catch (reason) {
-    return Promise.reject(reason);
+    return !!decoded?.isDev;
+  } catch {
+    return false;
   }
 };

--- a/src/utils/oauth.js
+++ b/src/utils/oauth.js
@@ -210,7 +210,6 @@ export const isUserDev = async () => {
   try {
     const {oauthTokens} = await getTokensCache();
     const {idToken = ''} = oauthTokens || {};
-    console.log('idToken', idToken);
     const decoded = jwtDecode(idToken);
     return decoded?.isDev;
   } catch (reason) {

--- a/src/utils/oauth.js
+++ b/src/utils/oauth.js
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {refresh, authorize} from 'react-native-app-auth';
+import jwtDecode from 'jwt-decode';
 import {parseJson, stringifyJson} from './json';
 import keys from '../keys';
 
@@ -196,5 +197,23 @@ export const isTokenExpired = async () => {
     return isExpired(expiration);
   } catch (reason) {
     return false;
+  }
+};
+
+/**
+ * @name isUserDev
+ * @description Asynchronously checks if the user is a developer by retrieving the isDev property from the token.
+ * @async
+ * @returns {Promise<boolean>} - Resolves to true if the user is a developer, false otherwise.
+ */
+export const isUserDev = async () => {
+  try {
+    const {oauthTokens} = await getTokensCache();
+    const {idToken = ''} = oauthTokens || {};
+    console.log('idToken', idToken);
+    const decoded = jwtDecode(idToken);
+    return decoded?.isDev;
+  } catch (reason) {
+    return Promise.reject(reason);
   }
 };

--- a/test/utils/oauth.test.js
+++ b/test/utils/oauth.test.js
@@ -1,5 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import {refresh, authorize} from 'react-native-app-auth';
+import jwtDecode from 'jwt-decode';
 import {
   storeTokensCache,
   parseExpirationDate,
@@ -11,8 +12,11 @@ import {
   getLoginObj,
   clearAuthorizeTokens,
   isTokenExpired,
+  isUserDev,
 } from '../../src/utils/oauth';
 import keys from '../../src/keys';
+
+jest.mock('jwt-decode');
 
 describe('OAuth Utils', () => {
   beforeEach(() => {
@@ -363,6 +367,51 @@ describe('OAuth Utils', () => {
           Promise.reject(new Error('AsyncStorage error')),
         );
       expect(await isTokenExpired()).toBe(false);
+    });
+  });
+
+  describe('isUserDev', () => {
+    it('should return isDev value from decoded token', async () => {
+      AsyncStorage.setItem(
+        keys.OAUTH_TOKENS_KEY,
+        JSON.stringify({idToken: 'mock.token'}),
+      );
+
+      jwtDecode.mockReturnValue({isDev: true});
+      expect(await isUserDev()).toBe(true);
+
+      jwtDecode.mockReturnValue({isDev: false});
+      expect(await isUserDev()).toBe(false);
+    });
+
+    it('should reject if idToken is missing', async () => {
+      AsyncStorage.setItem(
+        keys.OAUTH_TOKENS_KEY,
+        JSON.stringify({accessToken: 'token'}),
+      );
+      jwtDecode.mockImplementation(() => {
+        throw new Error('Invalid token');
+      });
+
+      try {
+        await isUserDev();
+        expect(true).toBe(false);
+      } catch (error) {
+        expect(error).toBeDefined();
+      }
+    });
+
+    it('should reject if oauthTokens is null', async () => {
+      jwtDecode.mockImplementation(() => {
+        throw new Error('Invalid token');
+      });
+
+      try {
+        await isUserDev();
+        expect(true).toBe(false);
+      } catch (error) {
+        expect(error).toBeDefined();
+      }
     });
   });
 });


### PR DESCRIPTION
LINK DE TICKET:
https://janiscommerce.atlassian.net/browse/APPSRN-458

DESCRIPCIÓN DEL REQUERIMIENTO:
Tras identificar que la validación isDev se puede llegar a usar en las tres APPs, se decidió crear un nuevo método en [oauth-native](https://github.com/janis-commerce/oauth-native) para poder reutilizarlo fácilmente a través de las APPs.

DESCRIPCIÓN DE LA SOLUCIÓN:
Se creó el método isUserDev para validar cuándo el usuario es dev a partir del idToken.

NIVEL PRUEBAS * ### (Marcar con X)

[ ] NIVEL CRITICO, CAMBIOS MAYORES

[ ] NIVEL ALTO, CAMBIOS MODERADOS

[ ] NIVEL MEDIO, CAMBIOS MENORES

[X] NIVEL BAJO, CAMBIOS NO CRITICOS

CÓMO SE PUEDE PROBAR?
Probar linkeando a una de las tres apps y verificando que la función devuelva si el usuario es dev o no

SCREENSHOTS:

DATOS EXTRA A TENER EN CUENTA:

CHANGELOG:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `isUserDev` to detect developer users from the `idToken` (via `jwt-decode`), exports it from the package, and adds tests.
> 
> - **Utils**:
>   - Add `isUserDev` in `src/utils/oauth.js` using `jwt-decode` to read `isDev` from `idToken`.
> - **Exports**:
>   - Re-export `isUserDev` from `src/index.js`.
> - **Tests**:
>   - Add `isUserDev` tests covering true/false, missing token, and null tokens.
>   - Mock `jwt-decode` in tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a174acf5bf3b97f7044eaa3bf7decaf6f358bb89. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a developer-status detection utility that reads the authenticated user's token to indicate developer privileges, enabling developer-specific behavior in the app.

* **Tests**
  * Added tests covering the new developer detection utility, including successful detection and error/edge-case handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->