### PR TITLE
APPSRN-514 Ampliar peer de react-native-app-auth a >=7.1.1 <8.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 
 ### Changed
-- Raised react-native-app-auth peer dependency to >=7.1.1 <9, requiring the version that fixes a fatal NPE on Android (`onActivityResult` after process death during the login flow) and unblocking apps to upgrade up to v8
+- Raised react-native-app-auth peer dependency to >=7.1.1 <8.4.0, requiring the version that fixes a fatal NPE on Android (`onActivityResult` after process death during the login flow) and unblocking apps to upgrade up to 8.3.x. 8.4.0 is excluded because it bumps AndroidX Browser to 1.9.0, requiring compileSdk 36 / AGP 8.9.1, above the apps' current setup.
 
 ### [1.13.0] - 2025-11-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Changed
+- Widened react-native-app-auth peer dependency to >=6.2.0 <9, allowing apps to upgrade to v7.1.1+ which fixes a fatal NPE on Android (`onActivityResult` after process death during the login flow)
+
 ### [1.13.0] - 2025-11-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [unreleased]
 
 ### Changed
-- Widened react-native-app-auth peer dependency to >=6.2.0 <9, allowing apps to upgrade to v7.1.1+ which fixes a fatal NPE on Android (`onActivityResult` after process death during the login flow)
+- Raised react-native-app-auth peer dependency to >=7.1.1 <9, requiring the version that fixes a fatal NPE on Android (`onActivityResult` after process death during the login flow) and unblocking apps to upgrade up to v8
 
 ### [1.13.0] - 2025-11-21
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "prettier": "^2.2.1",
         "react": "^16.13.1",
         "react-native": "^0.63.4",
-        "react-native-app-auth": "^6.2.0",
+        "react-native-app-auth": "^7.1.1",
         "react-native-inappbrowser-reborn": "^3.5.1",
         "react-test-renderer": "16.13.1"
       },
@@ -44,7 +44,7 @@
         "@react-navigation/native": "^6.1.6",
         "react": ">=16.13.1 <19.0.0",
         "react-native": ">=0.63.4 <0.75.0",
-        "react-native-app-auth": "^6.2.0",
+        "react-native-app-auth": ">=6.2.0 <9",
         "react-native-inappbrowser-reborn": "^3.5.1"
       }
     },
@@ -11344,10 +11344,11 @@
       }
     },
     "node_modules/react-native-app-auth": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/react-native-app-auth/-/react-native-app-auth-6.2.0.tgz",
-      "integrity": "sha512-TaQu4jiWO2C4Uj/3lM+QNfg826Eldh8ykxEK1DsQqfD68ZEms6GTjR2S3MegTsezoVug6utt+j/XrZlB26X1gA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-app-auth/-/react-native-app-auth-7.2.0.tgz",
+      "integrity": "sha512-Vw7td8oXklM0nXcerz/6E8Y6Ww+yDRMSohREllYceUe1570kNI7EIwGhzF3+yKjI4QADi8m/LGb7GdwkDxM4XQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "invariant": "2.2.4",
         "react-native-base64": "0.0.2"
@@ -23315,9 +23316,9 @@
       }
     },
     "react-native-app-auth": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/react-native-app-auth/-/react-native-app-auth-6.2.0.tgz",
-      "integrity": "sha512-TaQu4jiWO2C4Uj/3lM+QNfg826Eldh8ykxEK1DsQqfD68ZEms6GTjR2S3MegTsezoVug6utt+j/XrZlB26X1gA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/react-native-app-auth/-/react-native-app-auth-7.2.0.tgz",
+      "integrity": "sha512-Vw7td8oXklM0nXcerz/6E8Y6Ww+yDRMSohREllYceUe1570kNI7EIwGhzF3+yKjI4QADi8m/LGb7GdwkDxM4XQ==",
       "dev": true,
       "requires": {
         "invariant": "2.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@react-navigation/native": "^6.1.6",
         "react": ">=16.13.1 <19.0.0",
         "react-native": ">=0.63.4 <0.75.0",
-        "react-native-app-auth": ">=6.2.0 <9",
+        "react-native-app-auth": ">=7.1.1 <8.4.0",
         "react-native-inappbrowser-reborn": "^3.5.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "peerDependencies": {
     "react": ">=16.13.1 <19.0.0",
     "react-native": ">=0.63.4 <0.75.0",
-    "react-native-app-auth": ">=7.1.1 <9",
+    "react-native-app-auth": ">=7.1.1 <8.4.0",
     "react-native-inappbrowser-reborn": "^3.5.1",
     "@react-navigation/native": "^6.1.6"
   },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "peerDependencies": {
     "react": ">=16.13.1 <19.0.0",
     "react-native": ">=0.63.4 <0.75.0",
-    "react-native-app-auth": ">=6.2.0 <9",
+    "react-native-app-auth": ">=7.1.1 <9",
     "react-native-inappbrowser-reborn": "^3.5.1",
     "@react-navigation/native": "^6.1.6"
   },

--- a/package.json
+++ b/package.json
@@ -43,14 +43,14 @@
     "react": "^16.13.1",
     "react-native": "^0.63.4",
     "react-test-renderer": "16.13.1",
-    "react-native-app-auth": "^6.2.0",
+    "react-native-app-auth": "^7.1.1",
     "react-native-inappbrowser-reborn": "^3.5.1",
     "@react-navigation/native": "^6.1.6"
   },
   "peerDependencies": {
     "react": ">=16.13.1 <19.0.0",
     "react-native": ">=0.63.4 <0.75.0",
-    "react-native-app-auth": "^6.2.0",
+    "react-native-app-auth": ">=6.2.0 <9",
     "react-native-inappbrowser-reborn": "^3.5.1",
     "@react-navigation/native": "^6.1.6"
   },


### PR DESCRIPTION
## Link al ticket

* [APPSRN-514](https://janiscommerce.atlassian.net/browse/APPSRN-514)

## Descripción del requerimiento

Las apps tienen instalado `react-native-app-auth@6.4.3`, que crashea en Android cuando el sistema mata el proceso de la app durante el login (process death, frecuente en dispositivos de gama baja). Al retomar el Custom Tab, `onActivityResult` hace unboxing de un `Boolean` null en `RNAppAuthModule` y la app cierra. Es el 2º crash fatal de Delivery en producción: 265 eventos / 120 usuarios en 30 días (Crashlytics `07a98ff3`); afecta también a Orders e Inventory.

El fix existe upstream desde `react-native-app-auth@7.1.1`, pero el peer `^6.2.0` declarado en este package bloqueaba el upgrade en las apps con un error ERESOLVE.

## Descripción de la solución

Se amplía el `peerDependency` de `react-native-app-auth` de `^6.2.0` a **`>=7.1.1 <8.4.0`**, permitiendo a las apps subir a la versión con el fix sin conflicto de resolución.

* **Piso `7.1.1`**: primera versión que incluye el fix del crash (`Fix Android crash with NullPointerException`).
* **Techo `<8.4.0`**: `8.4.0` sube AndroidX Browser a `1.9.0`, que exige **compileSdk 36 / AGP 8.9.1**, por encima del setup actual de las apps (compileSdk 34 en v1, 35 en v2) → rompería el build. Se verificó versión por versión que **todo el rango `7.1.1 → 8.3.x` mantiene AndroidX Browser `1.4.0`** (el mismo requisito de compileSdk que el `6.4.3` actual) y que la API consumida (`authorize` / `refresh` en `src/utils/oauth.js`) es **idéntica** en ese rango (el diff de tipos es un único campo opcional aditivo).
* **Apps Android-only**: el cambio de `usePKCE` en iOS introducido en `8.0.0` no aplica — las apps no se distribuyen en iOS. En Android PKCE ya está activo por default y no cambia en todo el rango.

La devDependency se mantiene en `^7.1.1` (piso del rango soportado). No hay cambios en el código fuente; la API del wrapper es retrocompatible en todo el rango.

El lockfile se mantiene en `lockfileVersion 2` a propósito: el workflow `coverage-status.yml` de master corre con Node 12, que no soporta el formato v3 que generaría Node 18.

## Nivel de pruebas requerido

| MARCAR | NIVEL | DESCRIPCIÓN | CONDICIONES |
| --- | --- | --- | --- |
| [ ] | CRÍTICO: Cambios Mayores | Se consideran cambios que afectan partes fundamentales del sistema o funcionalidades que impactan múltiples módulos de la app. | Generar APK para pruebas. Utilizar perfil regular. Realizar pruebas exhaustivas en todos los módulos afectados. |
| [ ] | ALTO: Cambios moderados | Cambios que afectan aspectos importantes pero no críticos de la aplicación. | Se puede probar localmente, salvo que surja necesidad de crear un APK. Utilizar perfil regular para las pruebas. |
| [ ] | MEDIO: Cambios menores | Cambios menores que impactan una parte del flujo o ajustes que no modifican la funcionalidad general. | Validación localmente. Se puede usar perfil dev |
| [X] | BAJO: Ajustes | Modificaciones pequeñas que no impactan el rendimiento o funcionalidad general de la app. | Validación localmente. Se puede usar perfil dev |

## ¿Cómo se puede probar?

| Caso a probar | Resultado esperado | Resultado obtenido | Observaciones |
| --- | --- | --- | --- |
| Subir `react-native-app-auth` a `8.3.0` en una app consumidora (Delivery, Orders o Inventory) e instalar dependencias | npm resuelve sin ERESOLVE; el build de Android compila | _pendiente_ | Verifica que el rango ampliado desbloquea el upgrade hasta el tope soportado |
| Iniciar sesión en la app (Android) con la nueva versión instalada | El flujo OAuth completa correctamente | _pendiente_ | Happy path del login |
| Forzar process death durante el Custom Tab y retomar la app (Android) | La app no crashea; retoma el flujo correctamente | _pendiente_ | Reproduce el escenario del bug original (NPE en `onActivityResult`) |
| Refrescar token con la nueva versión instalada | El refresh funciona sin cambios de comportamiento | _pendiente_ | Cubre retrocompatibilidad de `refresh` |

## Evidencias, pruebas de cómo funciona

* _pendiente_

## Link a la documentación

* N/A

## Datos extra a tener en cuenta

* Tras el merge se libera `1.13.1` (patch). Se evita `1.14.0` para no colisionar con la línea `1.14.0-beta.x` ya publicada, que contiene los cambios de RN 0.80.
* **Esta línea (`1.13.x`) cubre v1** (picking, único repo que aún mantiene branch v1). Las apps v2 (Delivery, Orders, Inventory) se cubren por la línea `2.0.0-beta.x` (branch `APPSRN-475`), que debe aplicar el **mismo techo `<8.4.0`** (hoy está en `<9`).
* El techo `<8.4.0` deja como tope soportado la `8.3.0`. Para ir más allá (8.4.0+) las apps deberían subir antes a compileSdk 36 / AGP 8.9.1.
* Las apps son **Android-only**; no hay que validar nada en iOS.
* Los tests del package mockean `react-native-app-auth` por completo; la validación funcional del rango se hace en la app consumidora (ver casos de prueba).

## CHANGELOG:

```javascript
### Changed
- Widen `react-native-app-auth` peer dependency from `^6.2.0` to `>=7.1.1 <8.4.0`, allowing apps to upgrade to v7.1.1+ which fixes a fatal NPE on Android (`onActivityResult` after process death during login). 8.4.0 is excluded because it requires compileSdk 36 / AGP 8.9.1, above the apps' current setup [APPSRN-514](https://janiscommerce.atlassian.net/browse/APPSRN-514)
```


[APPSRN-514]: https://janiscommerce.atlassian.net/browse/APPSRN-514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPSRN-514]: https://janiscommerce.atlassian.net/browse/APPSRN-514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ